### PR TITLE
Apply dependency-analysis plugin to Android modules

### DIFF
--- a/build-logic/conventions/build.gradle.kts
+++ b/build-logic/conventions/build.gradle.kts
@@ -50,6 +50,10 @@ gradlePlugin {
             id = libs.plugins.toggles.android.lint.get().pluginId
             implementationClass = "se.eelde.toggles.conventions.AndroidLintConventionPlugin"
         }
+        register("dagp") {
+            id = libs.plugins.toggles.dagp.get().pluginId
+            implementationClass = "se.eelde.toggles.conventions.DagpConventionPlugin"
+        }
         register("detektCommon") {
             id = libs.plugins.toggles.detekt.common.get().pluginId
             implementationClass = "se.eelde.toggles.conventions.DetektConventionPlugin"

--- a/build-logic/conventions/src/main/kotlin/se/eelde/toggles/conventions/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/se/eelde/toggles/conventions/AndroidApplicationConventionPlugin.kt
@@ -17,6 +17,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             apply(plugin = "com.android.application")
             apply(plugin = "toggles.android.lint")
             apply(plugin = "toggles.detekt.common")
+            apply(plugin = "toggles.dagp")
 
             extensions.configure<ApplicationExtension> {
                 configureKotlinAndroid(this)

--- a/build-logic/conventions/src/main/kotlin/se/eelde/toggles/conventions/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/se/eelde/toggles/conventions/AndroidLibraryConventionPlugin.kt
@@ -17,6 +17,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             apply(plugin = "com.android.library")
             apply(plugin = "toggles.android.lint")
             apply(plugin = "toggles.detekt.library")
+            apply(plugin = "toggles.dagp")
             apply(plugin = "org.jetbrains.dokka")
             apply(plugin = "com.vanniktech.maven.publish")
             apply(plugin = "org.jetbrains.kotlinx.binary-compatibility-validator")

--- a/build-logic/conventions/src/main/kotlin/se/eelde/toggles/conventions/AndroidModuleConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/se/eelde/toggles/conventions/AndroidModuleConventionPlugin.kt
@@ -17,6 +17,7 @@ class AndroidModuleConventionPlugin : Plugin<Project> {
             apply(plugin = "com.android.library")
             apply(plugin = "toggles.android.lint")
             apply(plugin = "toggles.detekt.common")
+            apply(plugin = "toggles.dagp")
 
             extensions.configure<LibraryExtension> {
                 @Suppress("UnstableApiUsage")

--- a/build-logic/conventions/src/main/kotlin/se/eelde/toggles/conventions/DagpConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/se/eelde/toggles/conventions/DagpConventionPlugin.kt
@@ -1,0 +1,13 @@
+package se.eelde.toggles.conventions
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+
+class DagpConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            apply(plugin = "com.autonomousapps.dependency-analysis")
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -172,7 +172,7 @@ tapmoc-gradle-plugin = { module = "com.gradleup.tapmoc:com.gradleup.tapmoc.gradl
 android-application = { id = "com.android.application", version.ref = "agp" }
 com-android-library = { id = "com.android.library", version.ref = "agp" }
 com-android-lint = { id = "com.android.lint", version.ref = "agp" }
-com-autonomousapps-dependency-analysis = "com.autonomousapps.dependency-analysis:3.6.1"
+com-autonomousapps-dependency-analysis = "com.autonomousapps.dependency-analysis:3.9.0"
 com-github-triplet-play = "com.github.triplet.play:4.0.0"
 com-google-dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "com-google-dagger" }
 com-google-devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
@@ -192,6 +192,7 @@ toggles-android-compose-module = { id = "toggles.android.compose.module" }
 toggles-android-library = { id = "toggles.android.library" }
 toggles-android-lint = { id = "toggles.android.lint" }
 toggles-android-module = { id = "toggles.android.module" }
+toggles-dagp = { id = "toggles.dagp" }
 toggles-detekt-common = { id = "toggles.detekt.common" }
 toggles-detekt-library = { id = "toggles.detekt.library" }
 toggles-hilt = { id = "toggles.hilt" }


### PR DESCRIPTION
## Summary
- Bumps DAGP `3.6.1` → `3.9.0`
- Wires DAGP through a new `toggles.dagp` convention plugin applied from the Android application, library, and module convention plugins
- `./gradlew buildHealth` now analyzes all 25 subprojects instead of producing an empty report (previously DAGP was only applied at the root, so `projectCount` was 0)

This is the setup-only PR — dependency advice surfaced by the new buildHealth output (109 unused, 195 undeclared, 21 mis-declared, 57 runtime-only) will be triaged and applied in follow-up PRs batched by module family / advice type.

## Test plan
- [ ] `./gradlew buildHealth` succeeds and emits a non-empty `build/reports/dependency-analysis/build-health-report.txt`
- [ ] `./gradlew check` still passes
- [ ] Spot-check a few modules: `./gradlew :toggles-core:projectHealth`, `:modules:provider:implementation:projectHealth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)