### PR TITLE
Move androidx.startup runtime to runtimeOnly

### DIFF
--- a/modules/applications/build.gradle.kts
+++ b/modules/applications/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     debugImplementation(libs.androidx.compose.ui.ui.tooling)
     implementation(libs.androidx.compose.ui.ui.tooling.preview)
-    implementation(libs.androidx.startup.startup.runtime)
+    runtimeOnly(libs.androidx.startup.startup.runtime)
     implementation(libs.com.google.dagger.hilt.android)
     ksp(libs.com.google.dagger.hilt.compiler)
 }

--- a/modules/booleanconfiguration/build.gradle.kts
+++ b/modules/booleanconfiguration/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.compose.material3)
     debugImplementation(libs.androidx.compose.ui.ui.tooling)
-    implementation(libs.androidx.startup.startup.runtime)
+    runtimeOnly(libs.androidx.startup.startup.runtime)
     implementation(libs.com.google.dagger.hilt.android)
     implementation(projects.togglesCore)
     ksp(libs.com.google.dagger.hilt.compiler)

--- a/modules/configurations/build.gradle.kts
+++ b/modules/configurations/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     debugImplementation(libs.androidx.compose.ui.ui.tooling)
     implementation(libs.androidx.compose.material.material.icons.extended)
-    implementation(libs.androidx.startup.startup.runtime)
+    runtimeOnly(libs.androidx.startup.startup.runtime)
     implementation(libs.com.google.dagger.hilt.android)
     ksp(libs.com.google.dagger.hilt.compiler)
 }

--- a/modules/enumconfiguration/build.gradle.kts
+++ b/modules/enumconfiguration/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.material.icons.extended)
     debugImplementation(libs.androidx.compose.ui.ui.tooling)
-    implementation(libs.androidx.startup.startup.runtime)
+    runtimeOnly(libs.androidx.startup.startup.runtime)
     implementation(libs.com.google.dagger.hilt.android)
     implementation(projects.togglesCore)
     ksp(libs.com.google.dagger.hilt.compiler)

--- a/modules/help/build.gradle.kts
+++ b/modules/help/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.icons.core)
     debugImplementation(libs.androidx.compose.ui.ui.tooling)
-    implementation(libs.androidx.startup.startup.runtime)
+    runtimeOnly(libs.androidx.startup.startup.runtime)
     implementation(libs.com.google.dagger.hilt.android)
     ksp(libs.com.google.dagger.hilt.compiler)
 }

--- a/modules/integerconfiguration/build.gradle.kts
+++ b/modules/integerconfiguration/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     debugImplementation(libs.androidx.compose.ui.ui.tooling)
     implementation(libs.androidx.compose.ui.ui.tooling.preview)
-    implementation(libs.androidx.startup.startup.runtime)
+    runtimeOnly(libs.androidx.startup.startup.runtime)
     implementation(libs.com.google.dagger.hilt.android)
     implementation(projects.togglesCore)
     ksp(libs.com.google.dagger.hilt.compiler)

--- a/modules/provider/implementation/build.gradle.kts
+++ b/modules/provider/implementation/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation(projects.togglesCore)
     implementation(projects.togglesFlow)
     implementation(projects.modules.coroutines.api)
-    implementation(libs.androidx.startup.startup.runtime)
+    runtimeOnly(libs.androidx.startup.startup.runtime)
     implementation(libs.com.google.dagger.hilt.android)
     ksp(libs.com.google.dagger.hilt.compiler)
 

--- a/modules/stringconfiguration/build.gradle.kts
+++ b/modules/stringconfiguration/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     debugImplementation(libs.androidx.compose.ui.ui.tooling)
     implementation(libs.androidx.compose.ui.ui.tooling.preview)
-    implementation(libs.androidx.startup.startup.runtime)
+    runtimeOnly(libs.androidx.startup.startup.runtime)
     implementation(libs.com.google.dagger.hilt.android)
     implementation(projects.togglesCore)
     ksp(libs.com.google.dagger.hilt.compiler)

--- a/toggles-app/build.gradle.kts
+++ b/toggles-app/build.gradle.kts
@@ -129,7 +129,7 @@ dependencies {
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.lifecycle.viewmodel.navigation3)
     implementation(libs.androidx.hilt.hilt.navigation.compose)
-    implementation(libs.androidx.startup.startup.runtime)
+    runtimeOnly(libs.androidx.startup.startup.runtime)
     implementation(projects.modules.routes.api)
     ksp(libs.com.google.dagger.hilt.android.compiler)
 


### PR DESCRIPTION
## Summary
`androidx.startup` auto-discovers `Initializer` implementations at app launch via the AndroidX Startup `ContentProvider` — modules never compile against any of its types directly. Hosting it on `implementation` puts the artifact on the Kotlin/Java compile classpath of every consumer for no reason.

This PR switches the nine module-level declarations from `implementation` to `runtimeOnly`:

- `:toggles-app`
- `:modules:applications`
- `:modules:booleanconfiguration`
- `:modules:configurations`
- `:modules:enumconfiguration`
- `:modules:help`
- `:modules:integerconfiguration`
- `:modules:provider:implementation`
- `:modules:stringconfiguration`

Eliminates **9** buildHealth runtimeOnly-advice items.

> Note: stacked on top of #470 — this PR's base is `claude/dagp-cleanup-3` so the diff stays focused on the startup-runtime changes. Merge #470 first; this will then auto-retarget to `main`.

## Test plan
- [ ] `./gradlew compileDebugKotlin` succeeds across all touched modules (verified locally)
- [ ] App still launches and the Toggles `ContentProvider` is reachable (Startup auto-init still runs)
- [ ] `./gradlew buildHealth` shows zero advice for `androidx.startup:startup-runtime` (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)