### PR TITLE
Trim test-scope unused deps + demote LeakCanary to runtime-only

### DIFF
--- a/modules/database/implementation/build.gradle.kts
+++ b/modules/database/implementation/build.gradle.kts
@@ -43,7 +43,6 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.androidx.test.ext.junit)
     testImplementation(libs.androidx.room.room.testing)
-    testImplementation(libs.androidx.test.espresso.espresso.core)
 
     testFixturesImplementation(libs.androidx.room.room.runtime)
 }

--- a/modules/database/wiring/build.gradle.kts
+++ b/modules/database/wiring/build.gradle.kts
@@ -17,7 +17,5 @@ dependencies {
     implementation(libs.com.google.dagger.hilt.android)
     ksp(libs.com.google.dagger.hilt.compiler)
 
-    androidTestImplementation(libs.androidx.test.core.ktx)
     androidTestImplementation(libs.androidx.test.ext.junit)
-    androidTestImplementation(libs.androidx.arch.core.core.testing)
 }

--- a/modules/oss/build.gradle.kts
+++ b/modules/oss/build.gradle.kts
@@ -38,7 +38,4 @@ dependencies {
     implementation(libs.com.squareup.okio)
     implementation(libs.androidx.core.core.ktx)
     implementation(libs.androidx.appcompat)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.test.ext.junit)
-    androidTestImplementation(libs.androidx.test.espresso.espresso.core)
 }

--- a/modules/provider/implementation/build.gradle.kts
+++ b/modules/provider/implementation/build.gradle.kts
@@ -24,13 +24,8 @@ dependencies {
     ksp(libs.com.google.dagger.hilt.compiler)
 
     testImplementation(libs.junit)
-    testImplementation(libs.androidx.test.core.ktx)
-    testImplementation(libs.androidx.test.ext.truth)
-    testImplementation(libs.androidx.test.rules)
     testImplementation(libs.androidx.test.ext.junit)
     testImplementation(libs.org.robolectric)
-    testImplementation(libs.androidx.test.espresso.espresso.core)
-    testImplementation(libs.androidx.arch.core.core.testing)
     testImplementation(libs.com.google.dagger.hilt.android.testing)
     testImplementation(libs.org.jetbrains.kotlinx.kotlinx.coroutines.test)
     testImplementation(libs.app.cash.turbine)
@@ -41,7 +36,6 @@ dependencies {
     testFixturesImplementation(libs.org.robolectric)
     testFixturesImplementation(libs.androidx.core.core.ktx)
     testFixturesImplementation(projects.modules.database.implementation)
-    testFixturesImplementation(libs.androidx.room.room.runtime)
     testFixturesImplementation(libs.androidx.room.room.ktx)
     testFixturesImplementation(projects.togglesFlow)
 }

--- a/modules/provider/wiring/build.gradle.kts
+++ b/modules/provider/wiring/build.gradle.kts
@@ -13,7 +13,5 @@ dependencies {
     implementation(libs.com.google.dagger.hilt.android)
     ksp(libs.com.google.dagger.hilt.compiler)
 
-    androidTestImplementation(libs.androidx.test.core.ktx)
     androidTestImplementation(libs.androidx.test.ext.junit)
-    androidTestImplementation(libs.androidx.arch.core.core.testing)
 }

--- a/toggles-app/build.gradle.kts
+++ b/toggles-app/build.gradle.kts
@@ -147,7 +147,7 @@ dependencies {
     implementation(platform(libs.org.jetbrains.kotlinx.kotlinx.coroutines.bom))
     implementation(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
 
-    debugImplementation(libs.com.squareup.leakcanary.leakcanary.android)
+    debugRuntimeOnly(libs.com.squareup.leakcanary.leakcanary.android)
 
     androidTestImplementation(libs.androidx.test.core.ktx)
     androidTestImplementation(libs.androidx.test.ext.junit)
@@ -156,7 +156,6 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.ui.test.junit4)
     androidTestImplementation(libs.androidx.arch.core.core.testing)
     androidTestImplementation(libs.com.google.dagger.hilt.android.testing)
-    androidTestImplementation(libs.app.cash.turbine)
     kspAndroidTest(libs.com.google.dagger.hilt.android.compiler)
 
     testFixturesImplementation(libs.org.jetbrains.kotlin.kotlin.stdlib)

--- a/toggles-flow/build.gradle.kts
+++ b/toggles-flow/build.gradle.kts
@@ -24,14 +24,9 @@ dependencies {
 
     testImplementation(libs.junit)
 
-    testImplementation(libs.androidx.test.core.ktx)
-    testImplementation(libs.androidx.test.ext.truth)
-    testImplementation(libs.androidx.test.rules)
     testRuntimeOnly(libs.androidx.test.runner)
     testImplementation(libs.androidx.test.ext.junit)
     testImplementation(libs.org.robolectric)
-    testImplementation(libs.androidx.test.espresso.espresso.core)
-    testImplementation(libs.androidx.arch.core.core.testing)
     testImplementation(libs.org.jetbrains.kotlinx.kotlinx.coroutines.test)
     testImplementation(libs.app.cash.turbine)
     testImplementation(projects.modules.provider.implementation)

--- a/toggles-prefs/build.gradle.kts
+++ b/toggles-prefs/build.gradle.kts
@@ -19,9 +19,6 @@ dependencies {
 
     testImplementation(libs.junit)
 
-    testImplementation(libs.androidx.test.core.ktx)
-    testImplementation(libs.androidx.test.ext.truth)
-    testImplementation(libs.androidx.test.rules)
     testRuntimeOnly(libs.androidx.test.runner)
     testImplementation(libs.androidx.test.ext.junit)
     testImplementation(libs.org.robolectric)

--- a/toggles-sample/build.gradle.kts
+++ b/toggles-sample/build.gradle.kts
@@ -78,8 +78,7 @@ dependencies {
     implementation(platform(libs.org.jetbrains.kotlinx.kotlinx.coroutines.bom))
     implementation(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
 
-    debugImplementation(libs.com.squareup.leakcanary.leakcanary.android)
+    debugRuntimeOnly(libs.com.squareup.leakcanary.leakcanary.android)
 
-    androidTestImplementation(libs.androidx.test.core.ktx)
     androidTestImplementation(libs.androidx.test.ext.junit)
 }


### PR DESCRIPTION
## Summary
Bulk DAGP-driven cleanup that's safe to apply without coordinated additions:

**Test-scope unused removals (23 items)** — dead test declarations across `:modules:database:implementation`, `:modules:database:wiring`, `:modules:oss`, `:modules:provider:implementation`, `:modules:provider:wiring`, `:toggles-app`, `:toggles-flow`, `:toggles-prefs`, `:toggles-sample`. Drops unused `testImplementation` / `androidTestImplementation` / `testFixturesImplementation` entries that DAGP confirms aren't referenced from test code (espresso-core, arch-core-testing, test-core-ktx, test-rules, test-ext-truth, test-ext-junit, junit, room-runtime, turbine).

**LeakCanary demotion (2 items)** — the library auto-initializes via its `ContentProvider`, never compiled against. Moved to `debugRuntimeOnly` in `:toggles-app` and `:toggles-sample` so it stays off the debug compile classpath.

**Note**: Robolectric is left on `testImplementation` despite DAGP's `→ testRuntimeOnly` advice. Its `@Config` annotation and `Shadows.shadowOf` are referenced directly from test source — verified locally that demoting breaks `:toggles-flow:compileDebugUnitTestKotlin`.

Eliminates **25** buildHealth advice items.

## Test plan
- [ ] `./gradlew compileDebugKotlin compileDebugUnitTestKotlin compileDebugAndroidTestKotlin` succeeds (verified locally)
- [ ] `./gradlew test` still finds and runs all the unit tests
- [ ] LeakCanary still installs and detects leaks in debug builds (its initializer runs from `META-INF/services` regardless of compile classpath)

🤖 Generated with [Claude Code](https://claude.com/claude-code)