### PR TITLE
Trim remaining unused dependencies across modules

### DIFF
--- a/modules/applications/build.gradle.kts
+++ b/modules/applications/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(projects.modules.routes.api)
     implementation(libs.androidx.compose.material.icons.core)
     implementation(libs.androidx.navigation3.runtime)
-    implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.hilt.hilt.lifecycle.viewmodel.compose)
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.compose.material3)

--- a/modules/compose-theme/build.gradle.kts
+++ b/modules/compose-theme/build.gradle.kts
@@ -10,8 +10,6 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.navigation3.runtime)
-    implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.annotation)
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.runtime)

--- a/modules/configurations/build.gradle.kts
+++ b/modules/configurations/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(projects.modules.routes.api)
     implementation(libs.androidx.navigation3.runtime)
-    implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.hilt.hilt.lifecycle.viewmodel.compose)
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.compose.material3)

--- a/modules/database/implementation/build.gradle.kts
+++ b/modules/database/implementation/build.gradle.kts
@@ -32,9 +32,7 @@ ksp {
 dependencies {
     implementation(libs.androidx.room.room.runtime)
     ksp(libs.androidx.room.room.compiler)
-    implementation(libs.kotlinx.datetime)
     implementation(projects.togglesCore)
-    implementation(libs.androidx.appcompat)
 
     testImplementation(libs.androidx.test.ext.junit)
     testImplementation(libs.org.robolectric)

--- a/modules/help/build.gradle.kts
+++ b/modules/help/build.gradle.kts
@@ -10,9 +10,6 @@ android {
 
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.appcompat)
-    implementation(libs.androidx.navigation3.runtime)
-    implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.icons.core)

--- a/modules/oss/build.gradle.kts
+++ b/modules/oss/build.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
 
     implementation(libs.androidx.compose.material.material.icons.extended)
 
-    implementation(libs.androidx.compose.animation)
 
     implementation(libs.androidx.compose.ui.ui.tooling)
     implementation(libs.androidx.compose.ui.ui.tooling.preview)
@@ -29,12 +28,8 @@ dependencies {
 
     implementation(libs.com.google.dagger.hilt.android)
     ksp(libs.com.google.dagger.hilt.compiler)
-    implementation(libs.androidx.navigation3.runtime)
-    implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.hilt.hilt.lifecycle.viewmodel.compose)
 
-    implementation(libs.com.squareup.moshi)
-    implementation(libs.com.squareup.okio)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.compose.material.icons.core)
     implementation(libs.androidx.ui.graphics)

--- a/toggles-app/build.gradle.kts
+++ b/toggles-app/build.gradle.kts
@@ -95,7 +95,6 @@ android {
 
 dependencies {
     implementation(projects.modules.composeTheme)
-    implementation(libs.kotlinx.datetime)
     implementation(projects.modules.database.implementation)
     implementation(projects.modules.provider.implementation)
     implementation(projects.modules.applications)

--- a/toggles-flow-noop/build.gradle.kts
+++ b/toggles-flow-noop/build.gradle.kts
@@ -14,7 +14,6 @@ android {
 
 dependencies {
 
-    implementation(libs.androidx.annotation)
     implementation(platform(libs.org.jetbrains.kotlinx.kotlinx.coroutines.bom))
     implementation(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
     api(libs.org.jetbrains.kotlinx.kotlinx.coroutines.core)

--- a/toggles-flow/build.gradle.kts
+++ b/toggles-flow/build.gradle.kts
@@ -18,7 +18,6 @@ android {
 dependencies {
     implementation(projects.togglesCore)
 
-    implementation(libs.androidx.annotation)
     implementation(platform(libs.org.jetbrains.kotlinx.kotlinx.coroutines.bom))
     implementation(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
 

--- a/toggles-prefs-noop/build.gradle.kts
+++ b/toggles-prefs-noop/build.gradle.kts
@@ -14,7 +14,6 @@ android {
 
 dependencies {
 
-    implementation(libs.androidx.annotation)
 }
 
 val versionFile = File("versions.properties")

--- a/toggles-prefs/build.gradle.kts
+++ b/toggles-prefs/build.gradle.kts
@@ -15,7 +15,6 @@ android {
 dependencies {
     implementation(projects.togglesCore)
 
-    implementation(libs.androidx.annotation)
 
     testImplementation(libs.junit)
 


### PR DESCRIPTION
## Summary
Dropping the leftover unused-but-declared deps that DAGP confirms no module references after recent batches added the actually-used artifacts directly:

- `androidx.navigation3:navigation3-runtime` / `navigation3-ui` — `:modules:compose-theme`, `:modules:configurations`, `:modules:help`, `:modules:oss`, `:modules:applications`
- `androidx.appcompat:appcompat` — `:modules:database:implementation`, `:modules:help`
- `androidx.annotation:annotation` — `:toggles-flow`, `:toggles-flow-noop`, `:toggles-prefs`, `:toggles-prefs-noop`
- `org.jetbrains.kotlinx:kotlinx-datetime` — `:modules:database:implementation`, `:toggles-app`
- `androidx.compose.animation:animation` — `:modules:oss`
- `com.squareup.moshi:moshi` / `com.squareup.okio:okio` — `:modules:oss`

Eliminates **19** buildHealth unused-advice items (20 → 1).

> Stacked on top of #476. When #476 merges this rebases onto `main` automatically.

## Test plan
- [ ] `./gradlew compileDebugKotlin compileDebugUnitTestKotlin compileDebugAndroidTestKotlin compileDebugTestFixturesKotlin` succeeds (verified locally)
- [ ] `./gradlew check` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)