### PR TITLE
Apply remaining DAGP advice: api promotions + runtime-only demotions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,11 @@ robolectric = "4.16.1"
 se-eelde-toggles = "0.1.2"
 tapmoc = "0.4.1"
 
+androidx-collection = "1.5.0"
+androidx-sqlite = "2.6.0"
+errorprone-annotations = "2.43.0"
+guava = "33.4.8-android"
+
 [libraries]
 android-tools-common = { module = "com.android.tools:common", version.ref = "androidTools" }
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx-activity" }
@@ -57,6 +62,7 @@ androidx-activity-activity-compose = { module = "androidx.activity:activity-comp
 androidx-annotation = "androidx.annotation:annotation:1.9.1"
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-arch-core-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch-core" }
+androidx-collection = { module = "androidx.collection:collection", version.ref = "androidx-collection" }
 androidx-compose-animation = { module = "androidx.compose.animation:animation" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
@@ -112,6 +118,8 @@ androidx-room-room-compiler = { module = "androidx.room:room-compiler", version.
 androidx-room-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidx-room" }
 androidx-room-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidx-room" }
 androidx-room-room-testing = { module = "androidx.room:room-testing", version.ref = "androidx-room" }
+androidx-sqlite = { module = "androidx.sqlite:sqlite", version.ref = "androidx-sqlite" }
+androidx-sqlite-sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "androidx-sqlite" }
 androidx-startup-startup-runtime = "androidx.startup:startup-runtime:1.2.0"
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test" }
 androidx-test-core-ktx = { module = "androidx.test:core-ktx", version.ref = "androidx-test" }
@@ -144,7 +152,9 @@ com-google-dagger-hilt-android-testing = { module = "com.google.dagger:hilt-andr
 com-google-dagger-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "com-google-dagger" }
 com-google-dagger-hilt-core = { module = "com.google.dagger:hilt-core", version.ref = "hilt" }
 com-google-devtools-ksp-com-google-devtools-ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+com-google-errorprone-error-prone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorprone-annotations" }
 com-google-gms-google-services = "com.google.gms:google-services:4.4.4"
+com-google-guava-guava = { module = "com.google.guava:guava", version.ref = "guava" }
 com-slack-lint-compose-compose-lint-checks = "com.slack.lint.compose:compose-lint-checks:1.4.2"
 com-slack-lint-slack-lint-checks = "com.slack.lint:slack-lint-checks:0.11.1"
 com-squareup-kotlinpoet = "com.squareup:kotlinpoet:2.3.0"

--- a/modules/applications/build.gradle.kts
+++ b/modules/applications/build.gradle.kts
@@ -11,7 +11,7 @@ android {
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(projects.modules.composeTheme)
-    implementation(projects.modules.database.implementation)
+    api(projects.modules.database.implementation)
     implementation(libs.androidx.core.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(projects.modules.routes.api)

--- a/modules/booleanconfiguration/build.gradle.kts
+++ b/modules/booleanconfiguration/build.gradle.kts
@@ -10,9 +10,9 @@ android {
 
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
-    implementation(projects.modules.database.implementation)
+    api(projects.modules.database.implementation)
     implementation(projects.modules.provider.implementation)
-    implementation(projects.modules.routes.api)
+    api(projects.modules.routes.api)
     implementation(libs.androidx.compose.material.icons.core)
     implementation(projects.modules.coroutines.api)
     implementation(libs.androidx.appcompat)

--- a/modules/configurations/build.gradle.kts
+++ b/modules/configurations/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
-    implementation(projects.modules.database.implementation)
+    api(projects.modules.database.implementation)
     implementation(projects.togglesCore)
     implementation(libs.androidx.lifecycle.lifecycle.runtime.compose)
     implementation(libs.androidx.appcompat)

--- a/modules/coroutines/wiring/build.gradle.kts
+++ b/modules/coroutines/wiring/build.gradle.kts
@@ -8,7 +8,7 @@ android {
 }
 
 dependencies {
-    implementation(projects.modules.coroutines.api)
+    api(projects.modules.coroutines.api)
     ksp(libs.com.google.dagger.hilt.compiler)
     api(libs.com.google.dagger)
     implementation(libs.com.google.dagger.hilt.core)

--- a/modules/database/implementation/build.gradle.kts
+++ b/modules/database/implementation/build.gradle.kts
@@ -44,4 +44,8 @@ dependencies {
     api(libs.org.jetbrains.kotlinx.kotlinx.coroutines.core)
     implementation(libs.androidx.room.room.common)
     testImplementation(libs.androidx.test.monitor)
+    implementation(libs.androidx.collection)
+    testImplementation(libs.androidx.sqlite.sqlite.framework)
+    implementation(libs.androidx.sqlite)
+    testImplementation(libs.androidx.sqlite)
 }

--- a/modules/database/wiring/build.gradle.kts
+++ b/modules/database/wiring/build.gradle.kts
@@ -8,11 +8,11 @@ android {
 }
 
 dependencies {
-    implementation(projects.modules.database.implementation)
+    api(projects.modules.database.implementation)
 
     implementation(libs.androidx.room.room.runtime)
 
-    implementation(libs.com.google.dagger.hilt.android)
+    api(libs.com.google.dagger.hilt.android)
     ksp(libs.com.google.dagger.hilt.compiler)
 
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/modules/enumconfiguration/build.gradle.kts
+++ b/modules/enumconfiguration/build.gradle.kts
@@ -10,9 +10,9 @@ android {
 
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
-    implementation(projects.modules.database.implementation)
+    api(projects.modules.database.implementation)
     implementation(projects.modules.provider.implementation)
-    implementation(projects.modules.routes.api)
+    api(projects.modules.routes.api)
     implementation(libs.androidx.appcompat)
     implementation(projects.modules.coroutines.api)
     implementation(libs.androidx.hilt.hilt.lifecycle.viewmodel.compose)

--- a/modules/integerconfiguration/build.gradle.kts
+++ b/modules/integerconfiguration/build.gradle.kts
@@ -10,9 +10,9 @@ android {
 
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
-    implementation(projects.modules.database.implementation)
+    api(projects.modules.database.implementation)
     implementation(projects.modules.provider.implementation)
-    implementation(projects.modules.routes.api)
+    api(projects.modules.routes.api)
     implementation(libs.androidx.compose.material.icons.core)
     implementation(projects.modules.coroutines.api)
     implementation(libs.androidx.appcompat)

--- a/modules/provider/implementation/build.gradle.kts
+++ b/modules/provider/implementation/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 }
 dependencies {
     implementation(libs.kotlinx.datetime)
-    implementation(projects.modules.database.implementation)
+    api(projects.modules.database.implementation)
     implementation(libs.androidx.appcompat)
     implementation(projects.togglesCore)
     runtimeOnly(libs.androidx.startup.startup.runtime)
@@ -31,8 +31,8 @@ dependencies {
 
     testFixturesImplementation(libs.org.robolectric)
     testFixturesImplementation(libs.androidx.core.core.ktx)
-    testFixturesImplementation(projects.modules.database.implementation)
-    testFixturesImplementation(projects.togglesFlow)
+    testFixturesApi(projects.modules.database.implementation)
+    testFixturesApi(projects.togglesFlow)
     implementation(libs.androidx.annotation)
     testImplementation(libs.com.google.dagger)
     testImplementation(libs.javax.inject)
@@ -45,6 +45,8 @@ dependencies {
     testImplementation(libs.org.robolectric.annotations)
     testFixturesImplementation(libs.org.robolectric.shadows.framework)
     testImplementation(libs.org.robolectric.shadows.framework)
+    testImplementation(libs.com.google.errorprone.error.prone.annotations)
+    testImplementation(libs.com.google.guava.guava)
 }
 dependencies {
     testFixturesImplementation(libs.androidx.room.room.runtime)

--- a/modules/provider/wiring/build.gradle.kts
+++ b/modules/provider/wiring/build.gradle.kts
@@ -7,9 +7,9 @@ android {
     namespace = "se.eelde.toggles.provider.wiring"
 }
 dependencies {
-    implementation(projects.modules.provider.implementation)
+    api(projects.modules.provider.implementation)
 
-    implementation(libs.com.google.dagger.hilt.android)
+    api(libs.com.google.dagger.hilt.android)
     ksp(libs.com.google.dagger.hilt.compiler)
 
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/modules/stringconfiguration/build.gradle.kts
+++ b/modules/stringconfiguration/build.gradle.kts
@@ -11,9 +11,9 @@ android {
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(projects.modules.composeTheme)
-    implementation(projects.modules.database.implementation)
+    api(projects.modules.database.implementation)
     implementation(projects.modules.provider.implementation)
-    implementation(projects.modules.routes.api)
+    api(projects.modules.routes.api)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.compose.material.icons.core)
     implementation(libs.androidx.hilt.hilt.lifecycle.viewmodel.compose)

--- a/toggles-app/build.gradle.kts
+++ b/toggles-app/build.gradle.kts
@@ -136,11 +136,11 @@ dependencies {
     implementation(libs.com.google.dagger)
 
 
-    implementation(projects.togglesCore)
+    androidTestImplementation(projects.togglesCore)
     implementation(projects.togglesFlow)
 
     implementation(platform(libs.org.jetbrains.kotlinx.kotlinx.coroutines.bom))
-    implementation(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
+    runtimeOnly(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
 
     debugRuntimeOnly(libs.com.squareup.leakcanary.leakcanary.android)
 

--- a/toggles-flow-noop/build.gradle.kts
+++ b/toggles-flow-noop/build.gradle.kts
@@ -15,7 +15,7 @@ android {
 dependencies {
 
     implementation(platform(libs.org.jetbrains.kotlinx.kotlinx.coroutines.bom))
-    implementation(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
+    runtimeOnly(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
     api(libs.org.jetbrains.kotlinx.kotlinx.coroutines.core)
 }
 

--- a/toggles-flow/build.gradle.kts
+++ b/toggles-flow/build.gradle.kts
@@ -16,10 +16,10 @@ android {
 }
 
 dependencies {
-    implementation(projects.togglesCore)
+    api(projects.togglesCore)
 
     implementation(platform(libs.org.jetbrains.kotlinx.kotlinx.coroutines.bom))
-    implementation(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
+    runtimeOnly(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
 
     testImplementation(libs.junit)
 

--- a/toggles-prefs/build.gradle.kts
+++ b/toggles-prefs/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 }
 
 dependencies {
-    implementation(projects.togglesCore)
+    api(projects.togglesCore)
 
 
     testImplementation(libs.junit)

--- a/toggles-sample/build.gradle.kts
+++ b/toggles-sample/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     implementation(projects.togglesFlow)
 
     implementation(platform(libs.org.jetbrains.kotlinx.kotlinx.coroutines.bom))
-    implementation(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
+    runtimeOnly(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
 
     debugRuntimeOnly(libs.com.squareup.leakcanary.leakcanary.android)
 


### PR DESCRIPTION
## Summary
Final pass of safe DAGP advice — promotes internal-module deps to `api` where DAGP confirms types are exposed on the public Composable / DI surfaces, demotes `kotlinx-coroutines-android` to `runtimeOnly` where the module compiles only against `-core`, and rounds out the version catalog.

**API promotions** (internal modules — exposing types to direct consumers is fine, they're not published):
- `:modules:database:implementation` `impl → api` in 8 feature/wiring modules
- `:modules:routes:api` `impl → api` in 4 configuration modules
- `com.google.dagger:hilt-android` `impl → api` in `:modules:database:wiring`, `:modules:provider:wiring`
- `:toggles-core` `impl → api` in `:toggles-flow`, `:toggles-prefs` (these expose `ToggleState` on their `Toggles` interfaces)
- Plus testFixtures `api` promotions for `:modules:provider:implementation`

**Runtime-only demotions:**
- `org.jetbrains.kotlinx:kotlinx-coroutines-android` `impl → runtimeOnly` in `:toggles-app`, `:toggles-flow`, `:toggles-flow-noop`, `:toggles-sample` — these compile against `-core`; `-android` just adds the `Dispatchers.Main` implementation, loaded via service loader.

**Scope change:**
- `:toggles-core` `impl → androidTestImplementation` in `:toggles-app` (only used in instrumentation tests)

**New catalog entries:** `androidx.collection:collection`, `androidx.sqlite:sqlite` + `sqlite-framework`, `com.google.guava:guava`, `com.google.errorprone:error_prone_annotations`.

**Deliberately skipped:** `org.robolectric:robolectric` demotions (`testImpl → testRuntimeOnly`) in `:modules:database:implementation` and `:toggles-flow` — verified locally that those break compile because `@Config` and `Shadows.shadowOf` are referenced from test source.

Eliminates **29** buildHealth advice items (**34 → 5 remaining**).

## Test plan
- [ ] `./gradlew compileDebugKotlin compileDebugUnitTestKotlin compileDebugAndroidTestKotlin compileDebugTestFixturesKotlin` succeeds (verified locally)
- [ ] `./gradlew check` still passes
- [ ] No runtime regressions — `Dispatchers.Main` still works (kotlinx-coroutines-android service-loaded), Hilt still wires up, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)