### PR TITLE
Add hasOverride API to toggles-flow and toggles-prefs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,12 @@ Version catalog: `gradle/libs.versions.toml`. Properties: `gradle.properties` (1
 - **Serialization**: Moshi (JSON), kotlinx-serialization
 - **Static analysis**: Detekt (config: `config/detekt/detekt.yml`), slack-lint (custom lint checks — denies `java.util.Date` via `DenyListedApi`, denies unconditional `Log` calls in libraries via `LogConditional`)
 
+### Module Responsibilities
+
+**`toggles-core`** is strictly the ContentProvider contract module — it defines URI construction, column name constants, and the data types used to communicate with the ContentProvider (`Toggle`, `ToggleValue`, `TogglesConfiguration`, `TogglesConfigurationValue`, `ToggleScope`, `ToggleState`). It is not a shared-utilities module. Do not add business logic, API abstractions, or helper types here unless they are directly required for ContentProvider communication.
+
+Shared logic that does not belong in `toggles-core` goes in the library module that needs it (`toggles-flow`, `toggles-prefs`). Duplication between those two modules is preferable to polluting `toggles-core`.
+
 ### ContentProvider Architecture
 
 The core mechanism uses Android ContentProvider for inter-process communication between the Toggles app (provider) and consuming apps (clients). The `modules/provider/` module implements the provider side; `toggles-core/` implements the client side.

--- a/docs/superpowers/plans/2026-04-25-has-override.md
+++ b/docs/superpowers/plans/2026-04-25-has-override.md
@@ -220,8 +220,6 @@ Add these two test methods to the existing `FlowTest` class in `toggles-flow/src
 fun `hasOverride returns false for key with no overriding scope value`() = runTest {
     val toggles = TogglesImpl(context)
     val result = toggles.hasOverride("no-override-key").first()
-    @OptIn(ExperimentalCoroutinesApi::class)
-    advanceUntilIdle()
     assertFalse(result)
 }
 
@@ -234,8 +232,6 @@ fun `hasOverride passes ToggleState to custom comparator`() = runTest {
     }
     val toggles = TogglesImpl(context)
     toggles.hasOverride("some-key", capturingComparator).first()
-    @OptIn(ExperimentalCoroutinesApi::class)
-    advanceUntilIdle()
     assertNotNull(capturedState)
 }
 ```

--- a/docs/superpowers/plans/2026-04-25-has-override.md
+++ b/docs/superpowers/plans/2026-04-25-has-override.md
@@ -1,0 +1,788 @@
+# hasOverride Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `hasOverride(key, comparator)` to both `Toggles` and `TogglesPreferences` so consumers can detect when a toggle is being served from a non-default scope.
+
+**Architecture:** A `ScopeComparator` fun interface (defined independently in each library) takes a `ToggleState` and returns `Boolean`. A `DefaultScopeComparator` object implements the active-override check: selected scope ≠ default scope AND a value exists for the selected scope. The noop variants always return `false`. `ToggleState` is already available from `toggles-core`; no changes to `toggles-core` are needed.
+
+**Tech Stack:** Kotlin, Robolectric (unit tests), `toggles-core` types (`ToggleState`, `ToggleScope`, `TogglesConfigurationValue`, `TogglesConfiguration`, `ColumnNames`)
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Create | `toggles-flow/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt` |
+| Create | `toggles-flow/src/test/java/se/eelde/toggles/flow/DefaultScopeComparatorTest.kt` |
+| Modify | `toggles-flow/src/main/java/se/eelde/toggles/flow/Toggles.kt` |
+| Modify | `toggles-flow/src/main/java/se/eelde/toggles/flow/TogglesImpl.kt` |
+| Modify | `toggles-flow/src/test/java/se/eelde/toggles/flow/FlowTest.kt` |
+| Create | `toggles-flow-noop/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt` |
+| Modify | `toggles-flow-noop/src/main/java/se/eelde/toggles/flow/Toggles.kt` |
+| Modify | `toggles-flow-noop/src/main/java/se/eelde/toggles/flow/TogglesImpl.kt` |
+| Create | `toggles-prefs/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt` |
+| Create | `toggles-prefs/src/test/java/se/eelde/toggles/prefs/DefaultScopeComparatorTest.kt` |
+| Modify | `toggles-prefs/src/main/java/se/eelde/toggles/prefs/TogglesPreferences.kt` |
+| Modify | `toggles-prefs/src/main/java/se/eelde/toggles/prefs/TogglesPreferencesImpl.kt` |
+| Modify | `toggles-prefs/src/test/java/se/eelde/toggles/TogglesPreferencesReturnsProviderValues.kt` |
+| Create | `toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt` |
+| Modify | `toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/TogglesPreferences.kt` |
+| Modify | `toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/TogglesPreferencesImpl.kt` |
+
+---
+
+## Task 1: `ScopeComparator` in `toggles-flow`
+
+**Files:**
+- Create: `toggles-flow/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt`
+- Create: `toggles-flow/src/test/java/se/eelde/toggles/flow/DefaultScopeComparatorTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `toggles-flow/src/test/java/se/eelde/toggles/flow/DefaultScopeComparatorTest.kt`:
+
+```kotlin
+package se.eelde.toggles.flow
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import se.eelde.toggles.core.ColumnNames
+import se.eelde.toggles.core.ToggleScope
+import se.eelde.toggles.core.ToggleState
+import se.eelde.toggles.core.TogglesConfiguration
+import se.eelde.toggles.core.TogglesConfigurationValue
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+internal class DefaultScopeComparatorTest {
+
+    private val defaultScope = ToggleScope {
+        id = 1L
+        name = ColumnNames.ToggleScope.DEFAULT_SCOPE
+        timeStamp = Date(1000)
+    }
+
+    private val nonDefaultScope = ToggleScope {
+        id = 2L
+        name = "development"
+        timeStamp = Date(2000)
+    }
+
+    private val configuration = TogglesConfiguration {
+        id = 1L
+        type = "BOOLEAN"
+        key = "feature_x"
+    }
+
+    @Test
+    fun `returns false when scopes list is empty`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = emptyList(),
+            scopes = emptyList()
+        )
+        assertFalse(DefaultScopeComparator.hasOverride(state))
+    }
+
+    @Test
+    fun `returns false when only default scope exists`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = listOf(
+                TogglesConfigurationValue {
+                    id = 1L
+                    configurationId = 1L
+                    value = "true"
+                    scope = defaultScope.id
+                }
+            ),
+            scopes = listOf(defaultScope)
+        )
+        assertFalse(DefaultScopeComparator.hasOverride(state))
+    }
+
+    @Test
+    fun `returns false when non-default scope selected but has no value`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = listOf(
+                TogglesConfigurationValue {
+                    id = 1L
+                    configurationId = 1L
+                    value = "true"
+                    scope = defaultScope.id
+                }
+            ),
+            scopes = listOf(defaultScope, nonDefaultScope)
+        )
+        assertFalse(DefaultScopeComparator.hasOverride(state))
+    }
+
+    @Test
+    fun `returns true when non-default scope is selected and has a value`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = listOf(
+                TogglesConfigurationValue {
+                    id = 1L
+                    configurationId = 1L
+                    value = "true"
+                    scope = defaultScope.id
+                },
+                TogglesConfigurationValue {
+                    id = 2L
+                    configurationId = 1L
+                    value = "false"
+                    scope = nonDefaultScope.id
+                }
+            ),
+            scopes = listOf(defaultScope, nonDefaultScope)
+        )
+        assertTrue(DefaultScopeComparator.hasOverride(state))
+    }
+}
+```
+
+- [ ] **Step 2: Run test — expect compile failure (DefaultScopeComparator not defined)**
+
+```
+./gradlew :toggles-flow:test --tests "se.eelde.toggles.flow.DefaultScopeComparatorTest" --no-daemon
+```
+
+Expected: build failure — `Unresolved reference: DefaultScopeComparator`
+
+- [ ] **Step 3: Create `ScopeComparator.kt`**
+
+Create `toggles-flow/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt`:
+
+```kotlin
+package se.eelde.toggles.flow
+
+import se.eelde.toggles.core.ColumnNames
+import se.eelde.toggles.core.ToggleState
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public fun interface ScopeComparator {
+    public fun hasOverride(state: ToggleState): Boolean
+}
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public object DefaultScopeComparator : ScopeComparator {
+    override fun hasOverride(state: ToggleState): Boolean {
+        val defaultScope = state.scopes.firstOrNull { it.name == ColumnNames.ToggleScope.DEFAULT_SCOPE }
+        val selectedScope = state.scopes.maxByOrNull { it.timeStamp }
+        if (defaultScope == null || selectedScope == null) return false
+        if (defaultScope.id == selectedScope.id) return false
+        return state.configurationValues.any { it.scope == selectedScope.id }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — expect all 4 pass**
+
+```
+./gradlew :toggles-flow:test --tests "se.eelde.toggles.flow.DefaultScopeComparatorTest" --no-daemon
+```
+
+Expected output includes: `BUILD SUCCESSFUL` and 4 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toggles-flow/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt \
+        toggles-flow/src/test/java/se/eelde/toggles/flow/DefaultScopeComparatorTest.kt
+git commit -m "Add ScopeComparator and DefaultScopeComparator to toggles-flow"
+```
+
+---
+
+## Task 2: `hasOverride` in `toggles-flow` interface, implementation, and integration test
+
+**Files:**
+- Modify: `toggles-flow/src/main/java/se/eelde/toggles/flow/Toggles.kt`
+- Modify: `toggles-flow/src/main/java/se/eelde/toggles/flow/TogglesImpl.kt`
+- Modify: `toggles-flow/src/test/java/se/eelde/toggles/flow/FlowTest.kt`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add these two test methods to the existing `FlowTest` class in `toggles-flow/src/test/java/se/eelde/toggles/flow/FlowTest.kt`. Add the needed imports too: `import kotlinx.coroutines.flow.first`, `import org.junit.Assert.assertFalse`, `import org.junit.Assert.assertNotNull`, `import se.eelde.toggles.core.ToggleState`.
+
+```kotlin
+@Test
+fun `hasOverride returns false for key with no overriding scope value`() = runTest {
+    val toggles = TogglesImpl(context)
+    val result = toggles.hasOverride("no-override-key").first()
+    @OptIn(ExperimentalCoroutinesApi::class)
+    advanceUntilIdle()
+    assertFalse(result)
+}
+
+@Test
+fun `hasOverride passes ToggleState to custom comparator`() = runTest {
+    var capturedState: ToggleState? = null
+    val capturingComparator = ScopeComparator { state ->
+        capturedState = state
+        false
+    }
+    val toggles = TogglesImpl(context)
+    toggles.hasOverride("some-key", capturingComparator).first()
+    @OptIn(ExperimentalCoroutinesApi::class)
+    advanceUntilIdle()
+    assertNotNull(capturedState)
+}
+```
+
+- [ ] **Step 2: Run test — expect compile failure**
+
+```
+./gradlew :toggles-flow:test --tests "se.eelde.toggles.flow.FlowTest" --no-daemon
+```
+
+Expected: build failure — `Unresolved reference: hasOverride`
+
+- [ ] **Step 3: Add `hasOverride` to the `Toggles` interface**
+
+In `toggles-flow/src/main/java/se/eelde/toggles/flow/Toggles.kt`, add the import and new method. The full file after changes:
+
+```kotlin
+package se.eelde.toggles.flow
+
+import kotlinx.coroutines.flow.Flow
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public interface Toggles {
+    public fun toggle(key: String, defaultValue: Boolean): Flow<Boolean>
+    public fun toggle(key: String, defaultValue: String): Flow<String>
+    public fun toggle(key: String, defaultValue: Int): Flow<Int>
+    public fun <T : Enum<T>> toggle(
+        key: String,
+        type: Class<T>,
+        defaultValue: T
+    ): Flow<T>
+
+    public fun hasOverride(
+        key: String,
+        comparator: ScopeComparator = DefaultScopeComparator
+    ): Flow<Boolean>
+}
+```
+
+- [ ] **Step 4: Implement `hasOverride` in `TogglesImpl`**
+
+In `toggles-flow/src/main/java/se/eelde/toggles/flow/TogglesImpl.kt`, add the override after the last existing `toggle` override:
+
+```kotlin
+override fun hasOverride(key: String, comparator: ScopeComparator): Flow<Boolean> =
+    provider.observeToggleState(key).map { comparator.hasOverride(it) }
+```
+
+The import `import kotlinx.coroutines.flow.map` should already be present. If not, add it.
+
+- [ ] **Step 5: Run tests — expect all pass**
+
+```
+./gradlew :toggles-flow:test --tests "se.eelde.toggles.flow.FlowTest" --no-daemon
+```
+
+Expected: `BUILD SUCCESSFUL`, all tests pass including the two new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add toggles-flow/src/main/java/se/eelde/toggles/flow/Toggles.kt \
+        toggles-flow/src/main/java/se/eelde/toggles/flow/TogglesImpl.kt \
+        toggles-flow/src/test/java/se/eelde/toggles/flow/FlowTest.kt
+git commit -m "Add hasOverride to Toggles interface and TogglesImpl"
+```
+
+---
+
+## Task 3: `hasOverride` in `toggles-flow-noop`
+
+**Files:**
+- Create: `toggles-flow-noop/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt`
+- Modify: `toggles-flow-noop/src/main/java/se/eelde/toggles/flow/Toggles.kt`
+- Modify: `toggles-flow-noop/src/main/java/se/eelde/toggles/flow/TogglesImpl.kt`
+
+The noop module has its own copy of the `Toggles` interface and `ScopeComparator` (same package, separate module, no dependency on the main `toggles-flow` module).
+
+- [ ] **Step 1: Create `ScopeComparator.kt` in the noop module**
+
+Create `toggles-flow-noop/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt`:
+
+```kotlin
+package se.eelde.toggles.flow
+
+import se.eelde.toggles.core.ToggleState
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public fun interface ScopeComparator {
+    public fun hasOverride(state: ToggleState): Boolean
+}
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public object DefaultScopeComparator : ScopeComparator {
+    override fun hasOverride(state: ToggleState): Boolean = false
+}
+```
+
+Note: the noop `DefaultScopeComparator` always returns `false` — it exists only to satisfy the interface default parameter signature.
+
+- [ ] **Step 2: Update the noop `Toggles` interface**
+
+Replace the contents of `toggles-flow-noop/src/main/java/se/eelde/toggles/flow/Toggles.kt`:
+
+```kotlin
+package se.eelde.toggles.flow
+
+import kotlinx.coroutines.flow.Flow
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public interface Toggles {
+    public fun toggle(key: String, defaultValue: Boolean): Flow<Boolean>
+    public fun toggle(key: String, defaultValue: String): Flow<String>
+    public fun toggle(key: String, defaultValue: Int): Flow<Int>
+    public fun <T : Enum<T>> toggle(
+        key: String,
+        type: Class<T>,
+        defaultValue: T
+    ): Flow<T>
+
+    public fun hasOverride(
+        key: String,
+        comparator: ScopeComparator = DefaultScopeComparator
+    ): Flow<Boolean>
+}
+```
+
+- [ ] **Step 3: Implement `hasOverride` in the noop `TogglesImpl`**
+
+In `toggles-flow-noop/src/main/java/se/eelde/toggles/flow/TogglesImpl.kt`, add the import and override. The full file after changes:
+
+```kotlin
+package se.eelde.toggles.flow
+
+import android.content.Context
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public class TogglesImpl(@Suppress("UNUSED_PARAMETER") context: Context) : Toggles {
+    override fun toggle(key: String, defaultValue: Boolean): Flow<Boolean> = flowOf(defaultValue)
+    override fun toggle(key: String, defaultValue: Int): Flow<Int> = flowOf(defaultValue)
+    override fun toggle(key: String, defaultValue: String): Flow<String> = flowOf(defaultValue)
+    override fun <T : Enum<T>> toggle(key: String, type: Class<T>, defaultValue: T): Flow<T> = flowOf(defaultValue)
+    override fun hasOverride(key: String, comparator: ScopeComparator): Flow<Boolean> = flowOf(false)
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+```
+./gradlew :toggles-flow-noop:assembleDebug --no-daemon
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toggles-flow-noop/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt \
+        toggles-flow-noop/src/main/java/se/eelde/toggles/flow/Toggles.kt \
+        toggles-flow-noop/src/main/java/se/eelde/toggles/flow/TogglesImpl.kt
+git commit -m "Add hasOverride to toggles-flow-noop"
+```
+
+---
+
+## Task 4: `ScopeComparator` in `toggles-prefs`
+
+**Files:**
+- Create: `toggles-prefs/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt`
+- Create: `toggles-prefs/src/test/java/se/eelde/toggles/prefs/DefaultScopeComparatorTest.kt`
+
+Same logic as Task 1, different package.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `toggles-prefs/src/test/java/se/eelde/toggles/prefs/DefaultScopeComparatorTest.kt`:
+
+```kotlin
+package se.eelde.toggles.prefs
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import se.eelde.toggles.core.ColumnNames
+import se.eelde.toggles.core.ToggleScope
+import se.eelde.toggles.core.ToggleState
+import se.eelde.toggles.core.TogglesConfiguration
+import se.eelde.toggles.core.TogglesConfigurationValue
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.O])
+internal class DefaultScopeComparatorTest {
+
+    private val defaultScope = ToggleScope {
+        id = 1L
+        name = ColumnNames.ToggleScope.DEFAULT_SCOPE
+        timeStamp = Date(1000)
+    }
+
+    private val nonDefaultScope = ToggleScope {
+        id = 2L
+        name = "development"
+        timeStamp = Date(2000)
+    }
+
+    private val configuration = TogglesConfiguration {
+        id = 1L
+        type = "BOOLEAN"
+        key = "feature_x"
+    }
+
+    @Test
+    fun `returns false when scopes list is empty`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = emptyList(),
+            scopes = emptyList()
+        )
+        assertFalse(DefaultScopeComparator.hasOverride(state))
+    }
+
+    @Test
+    fun `returns false when only default scope exists`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = listOf(
+                TogglesConfigurationValue {
+                    id = 1L
+                    configurationId = 1L
+                    value = "true"
+                    scope = defaultScope.id
+                }
+            ),
+            scopes = listOf(defaultScope)
+        )
+        assertFalse(DefaultScopeComparator.hasOverride(state))
+    }
+
+    @Test
+    fun `returns false when non-default scope selected but has no value`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = listOf(
+                TogglesConfigurationValue {
+                    id = 1L
+                    configurationId = 1L
+                    value = "true"
+                    scope = defaultScope.id
+                }
+            ),
+            scopes = listOf(defaultScope, nonDefaultScope)
+        )
+        assertFalse(DefaultScopeComparator.hasOverride(state))
+    }
+
+    @Test
+    fun `returns true when non-default scope is selected and has a value`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = listOf(
+                TogglesConfigurationValue {
+                    id = 1L
+                    configurationId = 1L
+                    value = "true"
+                    scope = defaultScope.id
+                },
+                TogglesConfigurationValue {
+                    id = 2L
+                    configurationId = 1L
+                    value = "false"
+                    scope = nonDefaultScope.id
+                }
+            ),
+            scopes = listOf(defaultScope, nonDefaultScope)
+        )
+        assertTrue(DefaultScopeComparator.hasOverride(state))
+    }
+}
+```
+
+- [ ] **Step 2: Run test — expect compile failure**
+
+```
+./gradlew :toggles-prefs:test --tests "se.eelde.toggles.prefs.DefaultScopeComparatorTest" --no-daemon
+```
+
+Expected: build failure — `Unresolved reference: DefaultScopeComparator`
+
+- [ ] **Step 3: Create `ScopeComparator.kt`**
+
+Create `toggles-prefs/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt`:
+
+```kotlin
+package se.eelde.toggles.prefs
+
+import se.eelde.toggles.core.ColumnNames
+import se.eelde.toggles.core.ToggleState
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public fun interface ScopeComparator {
+    public fun hasOverride(state: ToggleState): Boolean
+}
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public object DefaultScopeComparator : ScopeComparator {
+    override fun hasOverride(state: ToggleState): Boolean {
+        val defaultScope = state.scopes.firstOrNull { it.name == ColumnNames.ToggleScope.DEFAULT_SCOPE }
+        val selectedScope = state.scopes.maxByOrNull { it.timeStamp }
+        if (defaultScope == null || selectedScope == null) return false
+        if (defaultScope.id == selectedScope.id) return false
+        return state.configurationValues.any { it.scope == selectedScope.id }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — expect all 4 pass**
+
+```
+./gradlew :toggles-prefs:test --tests "se.eelde.toggles.prefs.DefaultScopeComparatorTest" --no-daemon
+```
+
+Expected: `BUILD SUCCESSFUL`, 4 tests passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toggles-prefs/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt \
+        toggles-prefs/src/test/java/se/eelde/toggles/prefs/DefaultScopeComparatorTest.kt
+git commit -m "Add ScopeComparator and DefaultScopeComparator to toggles-prefs"
+```
+
+---
+
+## Task 5: `hasOverride` in `toggles-prefs` interface, implementation, and integration test
+
+**Files:**
+- Modify: `toggles-prefs/src/main/java/se/eelde/toggles/prefs/TogglesPreferences.kt`
+- Modify: `toggles-prefs/src/main/java/se/eelde/toggles/prefs/TogglesPreferencesImpl.kt`
+- Modify: `toggles-prefs/src/test/java/se/eelde/toggles/TogglesPreferencesReturnsProviderValues.kt`
+
+- [ ] **Step 1: Write the failing integration test**
+
+In `toggles-prefs/src/test/java/se/eelde/toggles/TogglesPreferencesReturnsProviderValues.kt`, add these imports at the top of the file:
+
+```kotlin
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import se.eelde.toggles.core.ToggleState
+import se.eelde.toggles.prefs.ScopeComparator
+```
+
+Then add these test methods to the `TogglesPreferencesReturnsProviderValues` class:
+
+```kotlin
+@Test
+fun `hasOverride returns false when no value stored for non-default scope`() {
+    // Mock returns 2 scopes: default (id=1) and "user" (id=2, higher timestamp).
+    // No value is stored for scope 2, so hasOverride must return false.
+    assertFalse(togglesPreferences.hasOverride("unknown-key"))
+}
+
+@Test
+fun `hasOverride passes ToggleState to custom comparator`() {
+    var capturedState: ToggleState? = null
+    val capturingComparator = ScopeComparator { state ->
+        capturedState = state
+        false
+    }
+    togglesPreferences.hasOverride("myKey", capturingComparator)
+    assertNotNull(capturedState)
+}
+```
+
+- [ ] **Step 2: Run test — expect compile failure**
+
+```
+./gradlew :toggles-prefs:test --tests "se.eelde.toggles.TogglesPreferencesReturnsProviderValues" --no-daemon
+```
+
+Expected: build failure — `Unresolved reference: hasOverride`
+
+- [ ] **Step 3: Add `hasOverride` to the `TogglesPreferences` interface**
+
+Replace the contents of `toggles-prefs/src/main/java/se/eelde/toggles/prefs/TogglesPreferences.kt`:
+
+```kotlin
+package se.eelde.toggles.prefs
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public interface TogglesPreferences {
+    public fun getBoolean(key: String, defaultValue: Boolean): Boolean
+    public fun getInt(key: String, defaultValue: Int): Int
+    public fun getString(key: String, defaultValue: String): String
+    public fun <T : Enum<T>> getEnum(key: String, type: Class<T>, defaultValue: T): T
+
+    public fun hasOverride(
+        key: String,
+        comparator: ScopeComparator = DefaultScopeComparator
+    ): Boolean
+}
+```
+
+- [ ] **Step 4: Implement `hasOverride` in `TogglesPreferencesImpl`**
+
+In `toggles-prefs/src/main/java/se/eelde/toggles/prefs/TogglesPreferencesImpl.kt`, add the override after the last existing `get*` override:
+
+```kotlin
+override fun hasOverride(key: String, comparator: ScopeComparator): Boolean =
+    comparator.hasOverride(provider.getToggleState(key))
+```
+
+- [ ] **Step 5: Run tests — expect all pass**
+
+```
+./gradlew :toggles-prefs:test --tests "se.eelde.toggles.TogglesPreferencesReturnsProviderValues" --no-daemon
+```
+
+Expected: `BUILD SUCCESSFUL`, all tests pass including the two new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add toggles-prefs/src/main/java/se/eelde/toggles/prefs/TogglesPreferences.kt \
+        toggles-prefs/src/main/java/se/eelde/toggles/prefs/TogglesPreferencesImpl.kt \
+        toggles-prefs/src/test/java/se/eelde/toggles/TogglesPreferencesReturnsProviderValues.kt
+git commit -m "Add hasOverride to TogglesPreferences interface and TogglesPreferencesImpl"
+```
+
+---
+
+## Task 6: `hasOverride` in `toggles-prefs-noop`
+
+**Files:**
+- Create: `toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt`
+- Modify: `toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/TogglesPreferences.kt`
+- Modify: `toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/TogglesPreferencesImpl.kt`
+
+- [ ] **Step 1: Create `ScopeComparator.kt` in the noop module**
+
+Create `toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt`:
+
+```kotlin
+package se.eelde.toggles.prefs
+
+import se.eelde.toggles.core.ToggleState
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public fun interface ScopeComparator {
+    public fun hasOverride(state: ToggleState): Boolean
+}
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public object DefaultScopeComparator : ScopeComparator {
+    override fun hasOverride(state: ToggleState): Boolean = false
+}
+```
+
+- [ ] **Step 2: Update the noop `TogglesPreferences` interface**
+
+Replace the contents of `toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/TogglesPreferences.kt`:
+
+```kotlin
+package se.eelde.toggles.prefs
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public interface TogglesPreferences {
+    public fun getBoolean(key: String, defValue: Boolean): Boolean
+    public fun getInt(key: String, defValue: Int): Int
+    public fun getString(key: String, defValue: String): String
+    public fun <T : Enum<T>> getEnum(key: String, type: Class<T>, defValue: T): T
+
+    public fun hasOverride(
+        key: String,
+        comparator: ScopeComparator = DefaultScopeComparator
+    ): Boolean
+}
+```
+
+Note: the noop interface uses `defValue` (not `defaultValue`) for the existing methods — preserve this spelling for consistency.
+
+- [ ] **Step 3: Implement `hasOverride` in the noop `TogglesPreferencesImpl`**
+
+In `toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/TogglesPreferencesImpl.kt`, add the override. The full file after changes (read the current file first to confirm existing content):
+
+```kotlin
+package se.eelde.toggles.prefs
+
+import android.content.Context
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public class TogglesPreferencesImpl(@Suppress("UNUSED_PARAMETER") context: Context) : TogglesPreferences {
+    override fun getBoolean(key: String, defValue: Boolean): Boolean = defValue
+    override fun getInt(key: String, defValue: Int): Int = defValue
+    override fun getString(key: String, defValue: String): String = defValue
+    override fun <T : Enum<T>> getEnum(key: String, type: Class<T>, defValue: T): T = defValue
+    override fun hasOverride(key: String, comparator: ScopeComparator): Boolean = false
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+```
+./gradlew :toggles-prefs-noop:assembleDebug --no-daemon
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt \
+        toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/TogglesPreferences.kt \
+        toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/TogglesPreferencesImpl.kt
+git commit -m "Add hasOverride to toggles-prefs-noop"
+```
+
+---
+
+## Task 7: Full check
+
+- [ ] **Step 1: Run all unit tests**
+
+```
+./gradlew :toggles-flow:test :toggles-prefs:test --no-daemon
+```
+
+Expected: `BUILD SUCCESSFUL`, all tests pass.
+
+- [ ] **Step 2: Run detekt**
+
+```
+./gradlew :toggles-flow:detekt :toggles-prefs:detekt :toggles-flow-noop:detekt :toggles-prefs-noop:detekt --no-daemon
+```
+
+Expected: `BUILD SUCCESSFUL` with no detekt violations.
+
+- [ ] **Step 3: Run full check on affected modules**
+
+```
+./gradlew :toggles-flow:check :toggles-prefs:check --no-daemon
+```
+
+Expected: `BUILD SUCCESSFUL`

--- a/docs/superpowers/specs/2026-04-24-has-override-design.md
+++ b/docs/superpowers/specs/2026-04-24-has-override-design.md
@@ -1,0 +1,97 @@
+# hasOverride API Design
+
+**Date:** 2026-04-24
+
+## Goal
+
+Allow consumers of `toggles-flow` and `toggles-prefs` to check whether a toggle configuration is currently being overridden from its default scope value. The primary use cases are debug/QA UI indicators, runtime logging, and guard logic.
+
+## Architectural constraint
+
+`toggles-core` is the ContentProvider contract module only. `ScopeComparator` and `DefaultScopeComparator` are not placed there. They live in `toggles-flow` and `toggles-prefs` respectively, with acceptable duplication between the two.
+
+## Public API
+
+### `ScopeComparator` (defined separately in each library)
+
+```kotlin
+fun interface ScopeComparator {
+    fun hasOverride(state: ToggleState): Boolean
+}
+```
+
+A `fun interface` so callers can pass a lambda for custom behavior. Takes a `ToggleState` (from `toggles-core`) which contains the full configuration, all scope values, and the scope list — everything needed to make an override determination.
+
+### `DefaultScopeComparator`
+
+```kotlin
+object DefaultScopeComparator : ScopeComparator {
+    override fun hasOverride(state: ToggleState): Boolean {
+        val defaultScope = state.scopes.firstOrNull { it.name == ToggleScope.DEFAULT_SCOPE }
+        val selectedScope = state.scopes.maxByOrNull { it.timeStamp }
+        if (defaultScope == null || selectedScope == null) return false
+        if (defaultScope.id == selectedScope.id) return false
+        return state.configurationValues.any { it.scope == selectedScope.id }
+    }
+}
+```
+
+Returns `true` when: the selected scope (highest timestamp) differs from the default scope AND there is a stored value for the selected scope for this toggle.
+
+### New interface methods
+
+**`toggles-flow` — `Toggles` interface:**
+```kotlin
+fun hasOverride(key: String, comparator: ScopeComparator = DefaultScopeComparator): Flow<Boolean>
+```
+
+**`toggles-prefs` — `TogglesPreferences` interface:**
+```kotlin
+fun hasOverride(key: String, comparator: ScopeComparator = DefaultScopeComparator): Boolean
+```
+
+## Implementation
+
+### `TogglesImpl` (`toggles-flow`)
+
+```kotlin
+override fun hasOverride(key: String, comparator: ScopeComparator): Flow<Boolean> =
+    provider.getToggleState(key).map { comparator.hasOverride(it) }
+```
+
+Reactive — emits whenever the underlying `ToggleState` changes (scope switches, value edits).
+
+### `TogglesPreferencesImpl` (`toggles-prefs`)
+
+```kotlin
+override fun hasOverride(key: String, comparator: ScopeComparator): Boolean =
+    comparator.hasOverride(provider.getToggleState(key))
+```
+
+Synchronous point-in-time read.
+
+### Noop variants
+
+Both `toggles-flow-noop` and `toggles-prefs-noop` return `false` unconditionally — no Toggles app connection means no overrides.
+
+### `TogglesProvider` prerequisite
+
+`ToggleState` is currently used internally. Verify during implementation whether `provider.getToggleState(key)` is already exposed or needs to be added to the internal `TogglesProvider` interface.
+
+## Testing
+
+### `DefaultScopeComparator` unit tests (one class per library)
+
+- Default scope is selected → `false`
+- Non-default scope selected, value exists for that scope → `true`
+- Non-default scope selected, no value for that scope → `false`
+- No scopes in state → `false`
+
+### `TogglesImpl` / `TogglesPreferencesImpl` integration tests
+
+- Flow emits updated value when scope changes
+- Custom `ScopeComparator` lambda is called with the correct `ToggleState`
+
+### Noop variant tests
+
+- `hasOverride()` returns `false` for any key

--- a/docs/superpowers/specs/2026-04-24-has-override-design.md
+++ b/docs/superpowers/specs/2026-04-24-has-override-design.md
@@ -27,7 +27,7 @@ A `fun interface` so callers can pass a lambda for custom behavior. Takes a `Tog
 ```kotlin
 object DefaultScopeComparator : ScopeComparator {
     override fun hasOverride(state: ToggleState): Boolean {
-        val defaultScope = state.scopes.firstOrNull { it.name == ToggleScope.DEFAULT_SCOPE }
+        val defaultScope = state.scopes.firstOrNull { it.name == ColumnNames.ToggleScope.DEFAULT_SCOPE }
         val selectedScope = state.scopes.maxByOrNull { it.timeStamp }
         if (defaultScope == null || selectedScope == null) return false
         if (defaultScope.id == selectedScope.id) return false
@@ -56,7 +56,7 @@ fun hasOverride(key: String, comparator: ScopeComparator = DefaultScopeComparato
 
 ```kotlin
 override fun hasOverride(key: String, comparator: ScopeComparator): Flow<Boolean> =
-    provider.getToggleState(key).map { comparator.hasOverride(it) }
+    provider.observeToggleState(key).map { comparator.hasOverride(it) }
 ```
 
 Reactive — emits whenever the underlying `ToggleState` changes (scope switches, value edits).

--- a/toggles-flow-noop/api/toggles-flow-noop.api
+++ b/toggles-flow-noop/api/toggles-flow-noop.api
@@ -1,4 +1,14 @@
+public final class se/eelde/toggles/flow/DefaultScopeComparator : se/eelde/toggles/flow/ScopeComparator {
+	public static final field INSTANCE Lse/eelde/toggles/flow/DefaultScopeComparator;
+	public fun hasOverride (Lse/eelde/toggles/core/ToggleState;)Z
+}
+
+public abstract interface class se/eelde/toggles/flow/ScopeComparator {
+	public abstract fun hasOverride (Lse/eelde/toggles/core/ToggleState;)Z
+}
+
 public abstract interface class se/eelde/toggles/flow/Toggles {
+	public abstract fun hasOverride (Ljava/lang/String;Lse/eelde/toggles/flow/ScopeComparator;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun toggle (Ljava/lang/String;I)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun toggle (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Enum;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun toggle (Ljava/lang/String;Ljava/lang/String;)Lkotlinx/coroutines/flow/Flow;
@@ -7,6 +17,7 @@ public abstract interface class se/eelde/toggles/flow/Toggles {
 
 public final class se/eelde/toggles/flow/TogglesImpl : se/eelde/toggles/flow/Toggles {
 	public fun <init> (Landroid/content/Context;)V
+	public fun hasOverride (Ljava/lang/String;Lse/eelde/toggles/flow/ScopeComparator;)Lkotlinx/coroutines/flow/Flow;
 	public fun toggle (Ljava/lang/String;I)Lkotlinx/coroutines/flow/Flow;
 	public fun toggle (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Enum;)Lkotlinx/coroutines/flow/Flow;
 	public fun toggle (Ljava/lang/String;Ljava/lang/String;)Lkotlinx/coroutines/flow/Flow;

--- a/toggles-flow-noop/api/toggles-flow-noop.api
+++ b/toggles-flow-noop/api/toggles-flow-noop.api
@@ -15,6 +15,10 @@ public abstract interface class se/eelde/toggles/flow/Toggles {
 	public abstract fun toggle (Ljava/lang/String;Z)Lkotlinx/coroutines/flow/Flow;
 }
 
+public final class se/eelde/toggles/flow/Toggles$DefaultImpls {
+	public static fun hasOverride$default (Lse/eelde/toggles/flow/Toggles;Ljava/lang/String;Lse/eelde/toggles/flow/ScopeComparator;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
 public final class se/eelde/toggles/flow/TogglesImpl : se/eelde/toggles/flow/Toggles {
 	public fun <init> (Landroid/content/Context;)V
 	public fun hasOverride (Ljava/lang/String;Lse/eelde/toggles/flow/ScopeComparator;)Lkotlinx/coroutines/flow/Flow;

--- a/toggles-flow-noop/build.gradle.kts
+++ b/toggles-flow-noop/build.gradle.kts
@@ -18,6 +18,14 @@ dependencies {
     implementation(platform(libs.org.jetbrains.kotlinx.kotlinx.coroutines.bom))
     runtimeOnly(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)
     api(libs.org.jetbrains.kotlinx.kotlinx.coroutines.core)
+
+    testImplementation(libs.junit)
+    testRuntimeOnly(libs.androidx.test.runner)
+    testImplementation(libs.androidx.test.ext.junit)
+    testImplementation(libs.org.robolectric)
+    testImplementation(libs.androidx.test.core)
+    testImplementation(platform(libs.org.jetbrains.kotlinx.kotlinx.coroutines.bom))
+    testImplementation(libs.org.jetbrains.kotlinx.kotlinx.coroutines.test)
 }
 
 val versionFile = File("versions.properties")

--- a/toggles-flow-noop/build.gradle.kts
+++ b/toggles-flow-noop/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 }
 
 dependencies {
+    implementation(projects.togglesCore)
 
     implementation(platform(libs.org.jetbrains.kotlinx.kotlinx.coroutines.bom))
     runtimeOnly(libs.org.jetbrains.kotlinx.kotlinx.coroutines.android)

--- a/toggles-flow-noop/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt
+++ b/toggles-flow-noop/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt
@@ -1,0 +1,13 @@
+package se.eelde.toggles.flow
+
+import se.eelde.toggles.core.ToggleState
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public fun interface ScopeComparator {
+    public fun hasOverride(state: ToggleState): Boolean
+}
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public object DefaultScopeComparator : ScopeComparator {
+    override fun hasOverride(state: ToggleState): Boolean = false
+}

--- a/toggles-flow-noop/src/main/java/se/eelde/toggles/flow/Toggles.kt
+++ b/toggles-flow-noop/src/main/java/se/eelde/toggles/flow/Toggles.kt
@@ -12,4 +12,9 @@ public interface Toggles {
         type: Class<T>,
         defaultValue: T
     ): Flow<T>
+
+    public fun hasOverride(
+        key: String,
+        comparator: ScopeComparator = DefaultScopeComparator
+    ): Flow<Boolean>
 }

--- a/toggles-flow-noop/src/main/java/se/eelde/toggles/flow/TogglesImpl.kt
+++ b/toggles-flow-noop/src/main/java/se/eelde/toggles/flow/TogglesImpl.kt
@@ -6,16 +6,9 @@ import kotlinx.coroutines.flow.flowOf
 
 @Suppress("LibraryEntitiesShouldNotBePublic")
 public class TogglesImpl(@Suppress("UNUSED_PARAMETER") context: Context) : Toggles {
-
     override fun toggle(key: String, defaultValue: Boolean): Flow<Boolean> = flowOf(defaultValue)
-
     override fun toggle(key: String, defaultValue: Int): Flow<Int> = flowOf(defaultValue)
-
     override fun toggle(key: String, defaultValue: String): Flow<String> = flowOf(defaultValue)
-
-    override fun <T : Enum<T>> toggle(
-        key: String,
-        type: Class<T>,
-        defaultValue: T
-    ): Flow<T> = flowOf(defaultValue)
+    override fun <T : Enum<T>> toggle(key: String, type: Class<T>, defaultValue: T): Flow<T> = flowOf(defaultValue)
+    override fun hasOverride(key: String, comparator: ScopeComparator): Flow<Boolean> = flowOf(false)
 }

--- a/toggles-flow-noop/src/test/java/se/eelde/toggles/flow/NoopToggleTest.kt
+++ b/toggles-flow-noop/src/test/java/se/eelde/toggles/flow/NoopToggleTest.kt
@@ -1,0 +1,35 @@
+package se.eelde.toggles.flow
+
+import android.app.Application
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+internal class NoopToggleTest {
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    @Test
+    fun `hasOverride always returns false`() = runTest {
+        val toggles = TogglesImpl(context)
+        assertFalse(toggles.hasOverride("any-key").first())
+    }
+
+    @Test
+    fun `hasOverride never invokes comparator`() = runTest {
+        var invoked = false
+        val capturingComparator = ScopeComparator { _ ->
+            invoked = true
+            false
+        }
+        TogglesImpl(context).hasOverride("any-key", capturingComparator).first()
+        assertFalse("comparator should never be called in noop implementation", invoked)
+    }
+}

--- a/toggles-flow/api/toggles-flow.api
+++ b/toggles-flow/api/toggles-flow.api
@@ -1,8 +1,22 @@
+public final class se/eelde/toggles/flow/DefaultScopeComparator : se/eelde/toggles/flow/ScopeComparator {
+	public static final field INSTANCE Lse/eelde/toggles/flow/DefaultScopeComparator;
+	public fun hasOverride (Lse/eelde/toggles/core/ToggleState;)Z
+}
+
+public abstract interface class se/eelde/toggles/flow/ScopeComparator {
+	public abstract fun hasOverride (Lse/eelde/toggles/core/ToggleState;)Z
+}
+
 public abstract interface class se/eelde/toggles/flow/Toggles {
+	public abstract fun hasOverride (Ljava/lang/String;Lse/eelde/toggles/flow/ScopeComparator;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun toggle (Ljava/lang/String;I)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun toggle (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Enum;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun toggle (Ljava/lang/String;Ljava/lang/String;)Lkotlinx/coroutines/flow/Flow;
 	public abstract fun toggle (Ljava/lang/String;Z)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class se/eelde/toggles/flow/Toggles$DefaultImpls {
+	public static fun hasOverride$default (Lse/eelde/toggles/flow/Toggles;Ljava/lang/String;Lse/eelde/toggles/flow/ScopeComparator;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class se/eelde/toggles/flow/TogglesImpl : se/eelde/toggles/flow/Toggles {
@@ -13,6 +27,7 @@ public final class se/eelde/toggles/flow/TogglesImpl : se/eelde/toggles/flow/Tog
 	public fun <init> (Landroid/content/Context;Lkotlinx/coroutines/CoroutineDispatcher;ZZLkotlin/jvm/functions/Function3;)V
 	public fun <init> (Landroid/content/Context;Lkotlinx/coroutines/CoroutineDispatcher;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function4;)V
 	public synthetic fun <init> (Landroid/content/Context;Lkotlinx/coroutines/CoroutineDispatcher;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function4;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun hasOverride (Ljava/lang/String;Lse/eelde/toggles/flow/ScopeComparator;)Lkotlinx/coroutines/flow/Flow;
 	public fun toggle (Ljava/lang/String;I)Lkotlinx/coroutines/flow/Flow;
 	public fun toggle (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Enum;)Lkotlinx/coroutines/flow/Flow;
 	public fun toggle (Ljava/lang/String;Ljava/lang/String;)Lkotlinx/coroutines/flow/Flow;

--- a/toggles-flow/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt
+++ b/toggles-flow/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt
@@ -13,8 +13,9 @@ public object DefaultScopeComparator : ScopeComparator {
     override fun hasOverride(state: ToggleState): Boolean {
         val defaultScope = state.scopes.firstOrNull { it.name == ColumnNames.ToggleScope.DEFAULT_SCOPE }
         val selectedScope = state.scopes.maxByOrNull { it.timeStamp }
-        if (defaultScope == null || selectedScope == null) return false
-        if (defaultScope.id == selectedScope.id) return false
-        return state.configurationValues.any { it.scope == selectedScope.id }
+        return defaultScope != null &&
+            selectedScope != null &&
+            defaultScope.id != selectedScope.id &&
+            state.configurationValues.any { it.scope == selectedScope.id }
     }
 }

--- a/toggles-flow/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt
+++ b/toggles-flow/src/main/java/se/eelde/toggles/flow/ScopeComparator.kt
@@ -1,0 +1,20 @@
+package se.eelde.toggles.flow
+
+import se.eelde.toggles.core.ColumnNames
+import se.eelde.toggles.core.ToggleState
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public fun interface ScopeComparator {
+    public fun hasOverride(state: ToggleState): Boolean
+}
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public object DefaultScopeComparator : ScopeComparator {
+    override fun hasOverride(state: ToggleState): Boolean {
+        val defaultScope = state.scopes.firstOrNull { it.name == ColumnNames.ToggleScope.DEFAULT_SCOPE }
+        val selectedScope = state.scopes.maxByOrNull { it.timeStamp }
+        if (defaultScope == null || selectedScope == null) return false
+        if (defaultScope.id == selectedScope.id) return false
+        return state.configurationValues.any { it.scope == selectedScope.id }
+    }
+}

--- a/toggles-flow/src/main/java/se/eelde/toggles/flow/Toggles.kt
+++ b/toggles-flow/src/main/java/se/eelde/toggles/flow/Toggles.kt
@@ -15,4 +15,9 @@ public interface Toggles {
         type: Class<T>,
         defaultValue: T
     ): Flow<T>
+
+    public fun hasOverride(
+        key: String,
+        comparator: ScopeComparator = DefaultScopeComparator
+    ): Flow<Boolean>
 }

--- a/toggles-flow/src/main/java/se/eelde/toggles/flow/TogglesImpl.kt
+++ b/toggles-flow/src/main/java/se/eelde/toggles/flow/TogglesImpl.kt
@@ -51,6 +51,9 @@ public class TogglesImpl @JvmOverloads constructor(
             )
         }.map { java.lang.Enum.valueOf(type, it) }
 
+    override fun hasOverride(key: String, comparator: ScopeComparator): Flow<Boolean> =
+        provider.observeToggleState(key).map { comparator.hasOverride(it) }
+
     private fun resolveFlow(
         key: String,
         type: String,

--- a/toggles-flow/src/test/java/se/eelde/toggles/flow/DefaultScopeComparatorTest.kt
+++ b/toggles-flow/src/test/java/se/eelde/toggles/flow/DefaultScopeComparatorTest.kt
@@ -1,0 +1,107 @@
+package se.eelde.toggles.flow
+
+import android.annotation.SuppressLint
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import se.eelde.toggles.core.ColumnNames
+import se.eelde.toggles.core.ToggleScope
+import se.eelde.toggles.core.ToggleState
+import se.eelde.toggles.core.TogglesConfiguration
+import se.eelde.toggles.core.TogglesConfigurationValue
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+@SuppressLint("DenyListedApi")
+internal class DefaultScopeComparatorTest {
+
+    private val defaultScope = ToggleScope {
+        id = 1L
+        name = ColumnNames.ToggleScope.DEFAULT_SCOPE
+        timeStamp = Date(1000)
+    }
+
+    private val nonDefaultScope = ToggleScope {
+        id = 2L
+        name = "development"
+        timeStamp = Date(2000)
+    }
+
+    private val configuration = TogglesConfiguration {
+        id = 1L
+        type = "BOOLEAN"
+        key = "feature_x"
+    }
+
+    @Test
+    fun `returns false when scopes list is empty`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = emptyList(),
+            scopes = emptyList()
+        )
+        assertFalse(DefaultScopeComparator.hasOverride(state))
+    }
+
+    @Test
+    fun `returns false when only default scope exists`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = listOf(
+                TogglesConfigurationValue {
+                    id = 1L
+                    configurationId = 1L
+                    value = "true"
+                    scope = defaultScope.id
+                }
+            ),
+            scopes = listOf(defaultScope)
+        )
+        assertFalse(DefaultScopeComparator.hasOverride(state))
+    }
+
+    @Test
+    fun `returns false when non-default scope selected but has no value`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = listOf(
+                TogglesConfigurationValue {
+                    id = 1L
+                    configurationId = 1L
+                    value = "true"
+                    scope = defaultScope.id
+                }
+            ),
+            scopes = listOf(defaultScope, nonDefaultScope)
+        )
+        assertFalse(DefaultScopeComparator.hasOverride(state))
+    }
+
+    @Test
+    fun `returns true when non-default scope is selected and has a value`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = listOf(
+                TogglesConfigurationValue {
+                    id = 1L
+                    configurationId = 1L
+                    value = "true"
+                    scope = defaultScope.id
+                },
+                TogglesConfigurationValue {
+                    id = 2L
+                    configurationId = 1L
+                    value = "false"
+                    scope = nonDefaultScope.id
+                }
+            ),
+            scopes = listOf(defaultScope, nonDefaultScope)
+        )
+        assertTrue(DefaultScopeComparator.hasOverride(state))
+    }
+}

--- a/toggles-flow/src/test/java/se/eelde/toggles/flow/FakeToggles.kt
+++ b/toggles-flow/src/test/java/se/eelde/toggles/flow/FakeToggles.kt
@@ -15,4 +15,7 @@ internal class FakeToggles : Toggles {
 
     override fun <T : Enum<T>> toggle(key: String, type: Class<T>, defaultValue: T): Flow<T> =
         flowOf(defaultValue)
+
+    override fun hasOverride(key: String, comparator: ScopeComparator): Flow<Boolean> =
+        flowOf(false)
 }

--- a/toggles-flow/src/test/java/se/eelde/toggles/flow/FlowTest.kt
+++ b/toggles-flow/src/test/java/se/eelde/toggles/flow/FlowTest.kt
@@ -4,13 +4,12 @@ import android.app.Application
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -45,8 +44,6 @@ internal class FlowTest {
     fun test() = runTest {
         val toggles = TogglesImpl(context)
         toggles.toggle("test item", "my value").first().apply {
-            @OptIn(ExperimentalCoroutinesApi::class)
-            advanceUntilIdle()
             assert(this == "my value")
         }
 
@@ -54,8 +51,6 @@ internal class FlowTest {
             .updateConfigurationValue(1, 1, "the test configuration value")
 
         toggles.toggle("test item", "my value").first().apply {
-            @OptIn(ExperimentalCoroutinesApi::class)
-            advanceUntilIdle()
             assert(this == "the test configuration value")
         }
     }
@@ -64,8 +59,6 @@ internal class FlowTest {
     fun `hasOverride returns false for key with no overriding scope value`() = runTest {
         val toggles = TogglesImpl(context)
         val result = toggles.hasOverride("no-override-key").first()
-        @OptIn(ExperimentalCoroutinesApi::class)
-        advanceUntilIdle()
         assertFalse(result)
     }
 
@@ -78,8 +71,7 @@ internal class FlowTest {
         }
         val toggles = TogglesImpl(context)
         toggles.hasOverride("some-key", capturingComparator).first()
-        @OptIn(ExperimentalCoroutinesApi::class)
-        advanceUntilIdle()
         assertNotNull(capturedState)
+        assertNull(capturedState!!.configuration) // unknown key → no configuration
     }
 }

--- a/toggles-flow/src/test/java/se/eelde/toggles/flow/FlowTest.kt
+++ b/toggles-flow/src/test/java/se/eelde/toggles/flow/FlowTest.kt
@@ -9,10 +9,13 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import se.eelde.toggles.core.ToggleState
 import se.eelde.toggles.database.FakeTogglesDatabase
 import se.eelde.toggles.database.TogglesDatabase
 import se.eelde.toggles.provider.RobolectricTogglesProvider
@@ -55,5 +58,28 @@ internal class FlowTest {
             advanceUntilIdle()
             assert(this == "the test configuration value")
         }
+    }
+
+    @Test
+    fun `hasOverride returns false for key with no overriding scope value`() = runTest {
+        val toggles = TogglesImpl(context)
+        val result = toggles.hasOverride("no-override-key").first()
+        @OptIn(ExperimentalCoroutinesApi::class)
+        advanceUntilIdle()
+        assertFalse(result)
+    }
+
+    @Test
+    fun `hasOverride passes ToggleState to custom comparator`() = runTest {
+        var capturedState: ToggleState? = null
+        val capturingComparator = ScopeComparator { state ->
+            capturedState = state
+            false
+        }
+        val toggles = TogglesImpl(context)
+        toggles.hasOverride("some-key", capturingComparator).first()
+        @OptIn(ExperimentalCoroutinesApi::class)
+        advanceUntilIdle()
+        assertNotNull(capturedState)
     }
 }

--- a/toggles-flow/src/test/java/se/eelde/toggles/flow/FlowTest.kt
+++ b/toggles-flow/src/test/java/se/eelde/toggles/flow/FlowTest.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -71,7 +70,7 @@ internal class FlowTest {
         }
         val toggles = TogglesImpl(context)
         toggles.hasOverride("some-key", capturingComparator).first()
-        assertNotNull(capturedState)
-        assertNull(capturedState!!.configuration) // unknown key → no configuration
+        val state = requireNotNull(capturedState)
+        assertNull(state.configuration) // unknown key → no configuration
     }
 }

--- a/toggles-flow/src/test/java/se/eelde/toggles/flow/FlowTest.kt
+++ b/toggles-flow/src/test/java/se/eelde/toggles/flow/FlowTest.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import se.eelde.toggles.database.TogglesConfigurationValue as DbConfigurationValue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -59,6 +61,20 @@ internal class FlowTest {
         val toggles = TogglesImpl(context)
         val result = toggles.hasOverride("no-override-key").first()
         assertFalse(result)
+    }
+
+    @Test
+    fun `hasOverride returns true when non-default scope has a value`() = runTest {
+        val toggles = TogglesImpl(context)
+        // Creates config (id=1), default scope (id=1), development scope (id=2, higher
+        // timestamp = selected), and a value for the default scope only.
+        toggles.toggle("override-key", "false").first()
+
+        // Insert a value for the non-default (development) scope — now an override exists.
+        database.togglesConfigurationValueDao()
+            .insertSync(DbConfigurationValue(id = 0L, configurationId = 1L, value = "true", scope = 2L))
+
+        assertTrue(toggles.hasOverride("override-key").first())
     }
 
     @Test

--- a/toggles-flow/src/test/java/se/eelde/toggles/flow/ToggleUriNotificationTest.kt
+++ b/toggles-flow/src/test/java/se/eelde/toggles/flow/ToggleUriNotificationTest.kt
@@ -12,7 +12,9 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import se.eelde.toggles.database.TogglesConfigurationValue as DbConfigurationValue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -123,6 +125,35 @@ internal class ToggleUriNotificationTest {
                 scopeUriObservers.isNotEmpty()
             )
 
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `hasOverride emits true after non-default scope value is inserted`() = runTest(testDispatcher) {
+        val toggles = TogglesImpl(context, ioDispatcher = testDispatcher)
+
+        // Bootstrap: create config (id=1), default scope (id=1), development scope (id=2,
+        // higher timestamp = selected), and a value for the default scope only.
+        toggles.toggle("reactive-key", "false").test {
+            advanceUntilIdle()
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        toggles.hasOverride("reactive-key").test {
+            advanceUntilIdle()
+            assertFalse(awaitItem()) // initial: false — no value for the selected (non-default) scope
+
+            // Insert a value for the non-default (development) scope, then notify observers.
+            database.togglesConfigurationValueDao()
+                .insertSync(DbConfigurationValue(id = 0L, configurationId = 1L, value = "true", scope = 2L))
+            context.contentResolver.notifyChange(TogglesProviderContract.configurationUri(), null)
+            shadowOf(Looper.getMainLooper()).idle()
+            advanceUntilIdle()
+
+            assertTrue(awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/toggles-prefs-noop/api/toggles-prefs-noop.api
+++ b/toggles-prefs-noop/api/toggles-prefs-noop.api
@@ -1,8 +1,22 @@
+public abstract interface class se/eelde/toggles/prefs/DefaultScopeComparator : se/eelde/toggles/prefs/ScopeComparator {
+	public static final field INSTANCE Lse/eelde/toggles/prefs/DefaultScopeComparator;
+	public fun hasOverride (Lse/eelde/toggles/core/ToggleState;)Z
+}
+
+public abstract interface class se/eelde/toggles/prefs/ScopeComparator {
+	public abstract fun hasOverride (Lse/eelde/toggles/core/ToggleState;)Z
+}
+
 public abstract interface class se/eelde/toggles/prefs/TogglesPreferences {
 	public abstract fun getBoolean (Ljava/lang/String;Z)Z
 	public abstract fun getEnum (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Enum;)Ljava/lang/Enum;
 	public abstract fun getInt (Ljava/lang/String;I)I
 	public abstract fun getString (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun hasOverride (Ljava/lang/String;Lse/eelde/toggles/prefs/ScopeComparator;)Z
+}
+
+public final class se/eelde/toggles/prefs/TogglesPreferences$DefaultImpls {
+	public static fun hasOverride$default (Lse/eelde/toggles/prefs/TogglesPreferences;Ljava/lang/String;Lse/eelde/toggles/prefs/ScopeComparator;ILjava/lang/Object;)Z
 }
 
 public final class se/eelde/toggles/prefs/TogglesPreferencesImpl : se/eelde/toggles/prefs/TogglesPreferences {
@@ -11,5 +25,6 @@ public final class se/eelde/toggles/prefs/TogglesPreferencesImpl : se/eelde/togg
 	public fun getEnum (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Enum;)Ljava/lang/Enum;
 	public fun getInt (Ljava/lang/String;I)I
 	public fun getString (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public fun hasOverride (Ljava/lang/String;Lse/eelde/toggles/prefs/ScopeComparator;)Z
 }
 

--- a/toggles-prefs-noop/api/toggles-prefs-noop.api
+++ b/toggles-prefs-noop/api/toggles-prefs-noop.api
@@ -1,4 +1,4 @@
-public abstract interface class se/eelde/toggles/prefs/DefaultScopeComparator : se/eelde/toggles/prefs/ScopeComparator {
+public final class se/eelde/toggles/prefs/DefaultScopeComparator : se/eelde/toggles/prefs/ScopeComparator {
 	public static final field INSTANCE Lse/eelde/toggles/prefs/DefaultScopeComparator;
 	public fun hasOverride (Lse/eelde/toggles/core/ToggleState;)Z
 }

--- a/toggles-prefs-noop/build.gradle.kts
+++ b/toggles-prefs-noop/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 }
 
 dependencies {
-
+    implementation(projects.togglesCore)
 }
 
 val versionFile = File("versions.properties")

--- a/toggles-prefs-noop/build.gradle.kts
+++ b/toggles-prefs-noop/build.gradle.kts
@@ -14,6 +14,12 @@ android {
 
 dependencies {
     implementation(projects.togglesCore)
+
+    testImplementation(libs.junit)
+    testRuntimeOnly(libs.androidx.test.runner)
+    testImplementation(libs.androidx.test.ext.junit)
+    testImplementation(libs.org.robolectric)
+    testImplementation(libs.androidx.test.core)
 }
 
 val versionFile = File("versions.properties")

--- a/toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt
+++ b/toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt
@@ -1,0 +1,13 @@
+package se.eelde.toggles.prefs
+
+import se.eelde.toggles.core.ToggleState
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public fun interface ScopeComparator {
+    public fun hasOverride(state: ToggleState): Boolean
+}
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public object DefaultScopeComparator : ScopeComparator {
+    override fun hasOverride(state: ToggleState): Boolean = false
+}

--- a/toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/TogglesPreferences.kt
+++ b/toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/TogglesPreferences.kt
@@ -6,4 +6,9 @@ public interface TogglesPreferences {
     public fun getInt(key: String, defValue: Int): Int
     public fun getString(key: String, defValue: String): String
     public fun <T : Enum<T>> getEnum(key: String, type: Class<T>, defValue: T): T
+
+    public fun hasOverride(
+        key: String,
+        comparator: ScopeComparator = DefaultScopeComparator
+    ): Boolean
 }

--- a/toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/TogglesPreferencesImpl.kt
+++ b/toggles-prefs-noop/src/main/java/se/eelde/toggles/prefs/TogglesPreferencesImpl.kt
@@ -12,4 +12,6 @@ public class TogglesPreferencesImpl(@Suppress("UNUSED_PARAMETER") context: Conte
     override fun getString(key: String, defValue: String): String = defValue
 
     override fun <T : Enum<T>> getEnum(key: String, type: Class<T>, defValue: T): T = defValue
+
+    override fun hasOverride(key: String, comparator: ScopeComparator): Boolean = false
 }

--- a/toggles-prefs-noop/src/test/java/se/eelde/toggles/prefs/NoopTogglesPreferencesTest.kt
+++ b/toggles-prefs-noop/src/test/java/se/eelde/toggles/prefs/NoopTogglesPreferencesTest.kt
@@ -1,0 +1,33 @@
+package se.eelde.toggles.prefs
+
+import android.app.Application
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.P])
+internal class NoopTogglesPreferencesTest {
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    @Test
+    fun `hasOverride always returns false`() {
+        val prefs = TogglesPreferencesImpl(context)
+        assertFalse(prefs.hasOverride("any-key"))
+    }
+
+    @Test
+    fun `hasOverride never invokes comparator`() {
+        var invoked = false
+        val capturingComparator = ScopeComparator { _ ->
+            invoked = true
+            false
+        }
+        TogglesPreferencesImpl(context).hasOverride("any-key", capturingComparator)
+        assertFalse("comparator should never be called in noop implementation", invoked)
+    }
+}

--- a/toggles-prefs/api/toggles-prefs.api
+++ b/toggles-prefs/api/toggles-prefs.api
@@ -1,10 +1,10 @@
-public abstract interface class se/eelde/toggles/prefs/ScopeComparator {
-	public abstract fun hasOverride (Lse/eelde/toggles/core/ToggleState;)Z
-}
-
 public final class se/eelde/toggles/prefs/DefaultScopeComparator : se/eelde/toggles/prefs/ScopeComparator {
 	public static final field INSTANCE Lse/eelde/toggles/prefs/DefaultScopeComparator;
 	public fun hasOverride (Lse/eelde/toggles/core/ToggleState;)Z
+}
+
+public abstract interface class se/eelde/toggles/prefs/ScopeComparator {
+	public abstract fun hasOverride (Lse/eelde/toggles/core/ToggleState;)Z
 }
 
 public abstract interface class se/eelde/toggles/prefs/TogglesPreferences {

--- a/toggles-prefs/api/toggles-prefs.api
+++ b/toggles-prefs/api/toggles-prefs.api
@@ -15,6 +15,10 @@ public abstract interface class se/eelde/toggles/prefs/TogglesPreferences {
 	public abstract fun hasOverride (Ljava/lang/String;Lse/eelde/toggles/prefs/ScopeComparator;)Z
 }
 
+public final class se/eelde/toggles/prefs/TogglesPreferences$DefaultImpls {
+	public static fun hasOverride$default (Lse/eelde/toggles/prefs/TogglesPreferences;Ljava/lang/String;Lse/eelde/toggles/prefs/ScopeComparator;ILjava/lang/Object;)Z
+}
+
 public final class se/eelde/toggles/prefs/TogglesPreferencesImpl : se/eelde/toggles/prefs/TogglesPreferences {
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Z)V

--- a/toggles-prefs/api/toggles-prefs.api
+++ b/toggles-prefs/api/toggles-prefs.api
@@ -1,8 +1,18 @@
+public abstract interface class se/eelde/toggles/prefs/ScopeComparator {
+	public abstract fun hasOverride (Lse/eelde/toggles/core/ToggleState;)Z
+}
+
+public final class se/eelde/toggles/prefs/DefaultScopeComparator : se/eelde/toggles/prefs/ScopeComparator {
+	public static final field INSTANCE Lse/eelde/toggles/prefs/DefaultScopeComparator;
+	public fun hasOverride (Lse/eelde/toggles/core/ToggleState;)Z
+}
+
 public abstract interface class se/eelde/toggles/prefs/TogglesPreferences {
 	public abstract fun getBoolean (Ljava/lang/String;Z)Z
 	public abstract fun getEnum (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Enum;)Ljava/lang/Enum;
 	public abstract fun getInt (Ljava/lang/String;I)I
 	public abstract fun getString (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun hasOverride (Ljava/lang/String;Lse/eelde/toggles/prefs/ScopeComparator;)Z
 }
 
 public final class se/eelde/toggles/prefs/TogglesPreferencesImpl : se/eelde/toggles/prefs/TogglesPreferences {
@@ -16,4 +26,5 @@ public final class se/eelde/toggles/prefs/TogglesPreferencesImpl : se/eelde/togg
 	public fun getEnum (Ljava/lang/String;Ljava/lang/Class;Ljava/lang/Enum;)Ljava/lang/Enum;
 	public fun getInt (Ljava/lang/String;I)I
 	public fun getString (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public fun hasOverride (Ljava/lang/String;Lse/eelde/toggles/prefs/ScopeComparator;)Z
 }

--- a/toggles-prefs/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt
+++ b/toggles-prefs/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt
@@ -13,8 +13,9 @@ public object DefaultScopeComparator : ScopeComparator {
     override fun hasOverride(state: ToggleState): Boolean {
         val defaultScope = state.scopes.firstOrNull { it.name == ColumnNames.ToggleScope.DEFAULT_SCOPE }
         val selectedScope = state.scopes.maxByOrNull { it.timeStamp }
-        if (defaultScope == null || selectedScope == null) return false
-        if (defaultScope.id == selectedScope.id) return false
-        return state.configurationValues.any { it.scope == selectedScope.id }
+        return defaultScope != null &&
+            selectedScope != null &&
+            defaultScope.id != selectedScope.id &&
+            state.configurationValues.any { it.scope == selectedScope.id }
     }
 }

--- a/toggles-prefs/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt
+++ b/toggles-prefs/src/main/java/se/eelde/toggles/prefs/ScopeComparator.kt
@@ -1,0 +1,20 @@
+package se.eelde.toggles.prefs
+
+import se.eelde.toggles.core.ColumnNames
+import se.eelde.toggles.core.ToggleState
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public fun interface ScopeComparator {
+    public fun hasOverride(state: ToggleState): Boolean
+}
+
+@Suppress("LibraryEntitiesShouldNotBePublic")
+public object DefaultScopeComparator : ScopeComparator {
+    override fun hasOverride(state: ToggleState): Boolean {
+        val defaultScope = state.scopes.firstOrNull { it.name == ColumnNames.ToggleScope.DEFAULT_SCOPE }
+        val selectedScope = state.scopes.maxByOrNull { it.timeStamp }
+        if (defaultScope == null || selectedScope == null) return false
+        if (defaultScope.id == selectedScope.id) return false
+        return state.configurationValues.any { it.scope == selectedScope.id }
+    }
+}

--- a/toggles-prefs/src/main/java/se/eelde/toggles/prefs/TogglesPreferences.kt
+++ b/toggles-prefs/src/main/java/se/eelde/toggles/prefs/TogglesPreferences.kt
@@ -6,4 +6,8 @@ public interface TogglesPreferences {
     public fun getInt(key: String, defaultValue: Int): Int
     public fun getString(key: String, defaultValue: String): String
     public fun <T : Enum<T>> getEnum(key: String, type: Class<T>, defaultValue: T): T
+    public fun hasOverride(
+        key: String,
+        comparator: ScopeComparator = DefaultScopeComparator
+    ): Boolean
 }

--- a/toggles-prefs/src/main/java/se/eelde/toggles/prefs/TogglesPreferencesImpl.kt
+++ b/toggles-prefs/src/main/java/se/eelde/toggles/prefs/TogglesPreferencesImpl.kt
@@ -54,4 +54,7 @@ public class TogglesPreferencesImpl @JvmOverloads constructor(
         }
         return java.lang.Enum.valueOf(type, result)
     }
+
+    override fun hasOverride(key: String, comparator: ScopeComparator): Boolean =
+        comparator.hasOverride(provider.getToggleState(key))
 }

--- a/toggles-prefs/src/test/java/se/eelde/toggles/TogglesPreferencesReturnsProviderValues.kt
+++ b/toggles-prefs/src/test/java/se/eelde/toggles/TogglesPreferencesReturnsProviderValues.kt
@@ -12,6 +12,9 @@ import android.os.Build.VERSION_CODES.O
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,7 +22,9 @@ import org.robolectric.Robolectric
 import org.robolectric.android.controller.ContentProviderController
 import org.robolectric.annotation.Config
 import se.eelde.toggles.core.ColumnNames
+import se.eelde.toggles.core.ToggleState
 import se.eelde.toggles.core.TogglesProviderContract
+import se.eelde.toggles.prefs.ScopeComparator
 import se.eelde.toggles.prefs.TogglesPreferences
 import se.eelde.toggles.prefs.TogglesPreferencesImpl
 
@@ -75,6 +80,25 @@ internal class TogglesPreferencesReturnsProviderValues {
     fun `return provider int when available`() {
         assertEquals(1, togglesPreferences.getInt(key, 1))
         assertEquals(1, togglesPreferences.getInt(key, 2))
+    }
+
+    @Test
+    fun `hasOverride returns false when no value stored for non-default scope`() {
+        // Mock returns 2 scopes: default (id=1) and "user" (id=2, higher timestamp).
+        // No value is stored for scope 2, so hasOverride must return false.
+        assertFalse(togglesPreferences.hasOverride("unknown-key"))
+    }
+
+    @Test
+    fun `hasOverride passes ToggleState to custom comparator`() {
+        var capturedState: ToggleState? = null
+        val capturingComparator = ScopeComparator { state ->
+            capturedState = state
+            false
+        }
+        togglesPreferences.hasOverride("myKey", capturingComparator)
+        assertNotNull(capturedState)
+        assertNull(capturedState!!.configuration) // unknown key → no configuration registered
     }
 }
 

--- a/toggles-prefs/src/test/java/se/eelde/toggles/TogglesPreferencesReturnsProviderValues.kt
+++ b/toggles-prefs/src/test/java/se/eelde/toggles/TogglesPreferencesReturnsProviderValues.kt
@@ -14,6 +14,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -79,6 +80,30 @@ internal class TogglesPreferencesReturnsProviderValues {
     fun `return provider int when available`() {
         assertEquals(1, togglesPreferences.getInt(key, 1))
         assertEquals(1, togglesPreferences.getInt(key, 2))
+    }
+
+    @Test
+    fun `hasOverride returns true when non-default scope has a value`() {
+        // The mock provider returns two scopes: DEFAULT_SCOPE (id=1, older) and "user" (id=2, newer).
+        // Pre-insert a configuration and a value for scope 2 (user = selected scope).
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        val configValues = ContentValues().apply {
+            put(ColumnNames.Configuration.COL_KEY, "override-key")
+            put(ColumnNames.Configuration.COL_TYPE, "BOOLEAN")
+        }
+        val configUri = requireNotNull(
+            context.contentResolver.insert(TogglesProviderContract.configurationUri(), configValues)
+        )
+        val configId = requireNotNull(configUri.lastPathSegment?.toLong())
+
+        val valueValues = ContentValues().apply {
+            put(ColumnNames.ConfigurationValue.COL_CONFIG_ID, configId)
+            put(ColumnNames.ConfigurationValue.COL_VALUE, "true")
+            put(ColumnNames.ConfigurationValue.COL_SCOPE, 2L)
+        }
+        context.contentResolver.insert(TogglesProviderContract.configurationValueUri(configId), valueValues)
+
+        assertTrue(togglesPreferences.hasOverride("override-key"))
     }
 
     @Test

--- a/toggles-prefs/src/test/java/se/eelde/toggles/TogglesPreferencesReturnsProviderValues.kt
+++ b/toggles-prefs/src/test/java/se/eelde/toggles/TogglesPreferencesReturnsProviderValues.kt
@@ -84,8 +84,7 @@ internal class TogglesPreferencesReturnsProviderValues {
 
     @Test
     fun `hasOverride returns false when no value stored for non-default scope`() {
-        // Mock returns 2 scopes: default (id=1) and "user" (id=2, higher timestamp).
-        // No value is stored for scope 2, so hasOverride must return false.
+        // Unknown key → no configuration registered → configurationValues empty → false
         assertFalse(togglesPreferences.hasOverride("unknown-key"))
     }
 

--- a/toggles-prefs/src/test/java/se/eelde/toggles/TogglesPreferencesReturnsProviderValues.kt
+++ b/toggles-prefs/src/test/java/se/eelde/toggles/TogglesPreferencesReturnsProviderValues.kt
@@ -13,7 +13,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -96,8 +95,8 @@ internal class TogglesPreferencesReturnsProviderValues {
             false
         }
         togglesPreferences.hasOverride("myKey", capturingComparator)
-        assertNotNull(capturedState)
-        assertNull(capturedState!!.configuration) // unknown key → no configuration registered
+        val state = requireNotNull(capturedState)
+        assertNull(state.configuration) // unknown key → no configuration registered
     }
 }
 

--- a/toggles-prefs/src/test/java/se/eelde/toggles/prefs/DefaultScopeComparatorTest.kt
+++ b/toggles-prefs/src/test/java/se/eelde/toggles/prefs/DefaultScopeComparatorTest.kt
@@ -1,0 +1,107 @@
+package se.eelde.toggles.prefs
+
+import android.annotation.SuppressLint
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import se.eelde.toggles.core.ColumnNames
+import se.eelde.toggles.core.ToggleScope
+import se.eelde.toggles.core.ToggleState
+import se.eelde.toggles.core.TogglesConfiguration
+import se.eelde.toggles.core.TogglesConfigurationValue
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.O])
+@SuppressLint("DenyListedApi")
+internal class DefaultScopeComparatorTest {
+
+    private val defaultScope = ToggleScope {
+        id = 1L
+        name = ColumnNames.ToggleScope.DEFAULT_SCOPE
+        timeStamp = Date(1000)
+    }
+
+    private val nonDefaultScope = ToggleScope {
+        id = 2L
+        name = "development"
+        timeStamp = Date(2000)
+    }
+
+    private val configuration = TogglesConfiguration {
+        id = 1L
+        type = "BOOLEAN"
+        key = "feature_x"
+    }
+
+    @Test
+    fun `returns false when scopes list is empty`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = emptyList(),
+            scopes = emptyList()
+        )
+        assertFalse(DefaultScopeComparator.hasOverride(state))
+    }
+
+    @Test
+    fun `returns false when only default scope exists`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = listOf(
+                TogglesConfigurationValue {
+                    id = 1L
+                    configurationId = 1L
+                    value = "true"
+                    scope = defaultScope.id
+                }
+            ),
+            scopes = listOf(defaultScope)
+        )
+        assertFalse(DefaultScopeComparator.hasOverride(state))
+    }
+
+    @Test
+    fun `returns false when non-default scope selected but has no value`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = listOf(
+                TogglesConfigurationValue {
+                    id = 1L
+                    configurationId = 1L
+                    value = "true"
+                    scope = defaultScope.id
+                }
+            ),
+            scopes = listOf(defaultScope, nonDefaultScope)
+        )
+        assertFalse(DefaultScopeComparator.hasOverride(state))
+    }
+
+    @Test
+    fun `returns true when non-default scope is selected and has a value`() {
+        val state = ToggleState(
+            configuration = configuration,
+            configurationValues = listOf(
+                TogglesConfigurationValue {
+                    id = 1L
+                    configurationId = 1L
+                    value = "true"
+                    scope = defaultScope.id
+                },
+                TogglesConfigurationValue {
+                    id = 2L
+                    configurationId = 1L
+                    value = "false"
+                    scope = nonDefaultScope.id
+                }
+            ),
+            scopes = listOf(defaultScope, nonDefaultScope)
+        )
+        assertTrue(DefaultScopeComparator.hasOverride(state))
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `hasOverride(key, comparator)` to the `Toggles` (Flow) and `TogglesPreferences` (Prefs) interfaces, letting consumers check whether a toggle is currently being served from a non-default scope
- Introduces `ScopeComparator` (`fun interface`) and `DefaultScopeComparator` in each library — consumers can pass a lambda for custom override detection logic
- Noop variants return `false` unconditionally; `.api` files updated manually (BCV unavailable under AGP 9)
- `toggles-core` is unchanged — clarified its purpose in CLAUDE.md as the ContentProvider contract module only

## Test Plan

- [ ] `./gradlew :toggles-flow:test :toggles-prefs:test` — all unit tests pass
- [ ] `./gradlew :toggles-flow:check :toggles-prefs:check` — detekt + lint clean
- [ ] `./gradlew :toggles-flow-noop:assembleDebug :toggles-prefs-noop:assembleDebug` — noop modules compile
- [ ] Verify `toggles-flow/api/toggles-flow.api` and `toggles-prefs/api/toggles-prefs.api` include new entries for `ScopeComparator`, `DefaultScopeComparator`, `hasOverride`, and `$DefaultImpls` bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)