### PR TITLE
Fix crash on concurrent configuration inserts (fixes #481)

### DIFF
--- a/modules/provider/implementation/src/main/java/se/eelde/toggles/provider/TogglesProvider.kt
+++ b/modules/provider/implementation/src/main/java/se/eelde/toggles/provider/TogglesProvider.kt
@@ -216,7 +216,7 @@ class TogglesProvider : ContentProvider() {
         return callingApplication.packageName == requireContext.packageName
     }
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "CyclomaticComplexMethod")
     override fun insert(uri: Uri, values: ContentValues?): Uri {
         val callingApplication = getCallingApplication(applicationDao)
 
@@ -293,14 +293,11 @@ class TogglesProvider : ContentProvider() {
                     type = togglesConfiguration.type,
                     lastUse = clock.now(),
                 )
-                @Suppress("SwallowedException")
                 insertId = try {
                     configurationDao.insert(databaseConfiguration)
                 } catch (e: SQLiteConstraintException) {
-                    configurationDao.getTogglesConfiguration(
-                        callingApplication.id,
-                        togglesConfiguration.key
-                    )?.id ?: -1L
+                    configurationDao.getTogglesConfiguration(callingApplication.id, togglesConfiguration.key)?.id
+                        ?: throw e
                 }
                 crossNotifyUri = TogglesProviderContract.toggleUri(insertId)
             }

--- a/modules/provider/implementation/src/main/java/se/eelde/toggles/provider/TogglesProvider.kt
+++ b/modules/provider/implementation/src/main/java/se/eelde/toggles/provider/TogglesProvider.kt
@@ -293,7 +293,15 @@ class TogglesProvider : ContentProvider() {
                     type = togglesConfiguration.type,
                     lastUse = clock.now(),
                 )
-                insertId = configurationDao.insert(databaseConfiguration)
+                @Suppress("SwallowedException")
+                insertId = try {
+                    configurationDao.insert(databaseConfiguration)
+                } catch (e: SQLiteConstraintException) {
+                    configurationDao.getTogglesConfiguration(
+                        callingApplication.id,
+                        togglesConfiguration.key
+                    )?.id ?: -1L
+                }
                 crossNotifyUri = TogglesProviderContract.toggleUri(insertId)
             }
 

--- a/modules/provider/implementation/src/test/java/se/eelde/toggles/provider/configuration/TogglesProviderMatcherConfigurationTest.kt
+++ b/modules/provider/implementation/src/test/java/se/eelde/toggles/provider/configuration/TogglesProviderMatcherConfigurationTest.kt
@@ -114,6 +114,25 @@ class TogglesProviderMatcherConfigurationTest {
         }
     }
 
+    @Test
+    fun testInsertDuplicateKeyReturnsSameId() {
+        val togglesConfiguration = TogglesConfiguration {
+            type = Toggle.TYPE.BOOLEAN
+            key = "duplicateKey"
+        }
+
+        val uri1 = togglesProvider.insert(
+            TogglesProviderContract.configurationUri(),
+            togglesConfiguration.toContentValues(),
+        )
+        val uri2 = togglesProvider.insert(
+            TogglesProviderContract.configurationUri(),
+            togglesConfiguration.toContentValues(),
+        )
+
+        assertEquals(uri1.toString(), uri2.toString())
+    }
+
     @Test(expected = UnsupportedOperationException::class)
     fun testDelete() {
         togglesProvider.delete(


### PR DESCRIPTION
## Summary

- `UriMatch.CONFIGURATIONS` in `TogglesProvider.insert` did not handle `SQLiteConstraintException` on UNIQUE constraint violations (`configuration.applicationId, configuration.configurationKey`)
- All other insert cases (`PREDEFINED_CONFIGURATION_VALUES`, `CONFIGURATION_VALUE_ID`) already caught this exception gracefully — `CONFIGURATIONS` was the odd one out
- Under concurrent access (two `Flow` or `SharedPreferences` observers for the same key both seeing it missing and both trying to insert), the second insert propagated the `SQLiteConstraintException` over IPC to the client and crashed the app
- Fix: catch the exception and fall back to querying the existing configuration by `(applicationId, key)`, returning its ID — consistent with the pattern used in the other cases
- Regression test added: inserting the same key twice returns the same URI both times

## Test plan

- [x] New test `testInsertDuplicateKeyReturnsSameId` in `TogglesProviderMatcherConfigurationTest` passes
- [x] Full provider unit test suite passes (`./gradlew :modules:provider:implementation:test`)

Fixes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)