### PR TITLE
Remove global lock contention from TogglesProvider hot path

### DIFF
--- a/modules/provider/implementation/src/main/java/se/eelde/toggles/provider/TogglesProvider.kt
+++ b/modules/provider/implementation/src/main/java/se/eelde/toggles/provider/TogglesProvider.kt
@@ -94,33 +94,42 @@ class TogglesProvider : ContentProvider() {
         fun provideClock(): Clock
     }
 
-    private fun getCallingApplication(applicationDao: ProviderApplicationDao): TogglesApplication =
-        synchronized(this) {
-            val callingPackageName = packageManagerWrapper.callingApplicationPackageName
+    // Guards only the rare first-touch initialisation (create application row + its scopes) so that
+    // it happens exactly once per calling app. Steady-state reads acquire no lock — see
+    // getCallingApplication().
+    private val initLock = Any()
 
-            var togglesApplication: TogglesApplication? =
-                applicationDao.loadByPackageName(callingPackageName)
+    private fun getCallingApplication(applicationDao: ProviderApplicationDao): TogglesApplication {
+        val callingPackageName = packageManagerWrapper.callingApplicationPackageName
 
-            if (togglesApplication == null) {
-                togglesApplication = TogglesApplication(
-                    id = 0,
-                    packageName = callingPackageName,
-                    applicationLabel = packageManagerWrapper.applicationLabel,
-                    shortcutId = callingPackageName,
-                )
+        // Fast path: the calling app is already registered. No lock needed for a read.
+        applicationDao.loadByPackageName(callingPackageName)?.let { return it }
 
-                togglesApplication.id = applicationDao.insert(togglesApplication)
+        // Slow path: first time we've seen this calling app. Serialise creation so concurrent
+        // first-touch callers don't insert duplicate applications/scopes.
+        return synchronized(initLock) {
+            // Re-check: another thread may have created it while we waited for the lock.
+            applicationDao.loadByPackageName(callingPackageName)?.let { return@synchronized it }
 
-                createDefaultScope(scopeDao, togglesApplication.id, clock)
-                createDevelopmentScope(scopeDao, togglesApplication.id, clock)
+            val togglesApplication = TogglesApplication(
+                id = 0,
+                packageName = callingPackageName,
+                applicationLabel = packageManagerWrapper.applicationLabel,
+                shortcutId = callingPackageName,
+            )
 
-                requireContext.contentResolver.notifyInsert(
-                    TogglesProviderContract.scopeUri()
-                )
-            }
+            togglesApplication.id = applicationDao.insert(togglesApplication)
 
-            return togglesApplication
+            createDefaultScope(scopeDao, togglesApplication.id, clock)
+            createDevelopmentScope(scopeDao, togglesApplication.id, clock)
+
+            requireContext.contentResolver.notifyInsert(
+                TogglesProviderContract.scopeUri()
+            )
+
+            togglesApplication
         }
+    }
 
     override fun onCreate() = true
 
@@ -515,14 +524,12 @@ class TogglesProvider : ContentProvider() {
 
         private const val oneSecond = 1000L
 
-        @Synchronized
         private fun getDefaultScope(
             scopeDao: ProviderScopeDao,
             applicationId: Long
         ): TogglesScope = scopeDao.getDefaultScope(applicationId)
             ?: error("No default scope for application $applicationId")
 
-        @Synchronized
         private fun getSelectedScope(
             scopeDao: ProviderScopeDao,
             applicationId: Long
@@ -554,7 +561,6 @@ class TogglesProvider : ContentProvider() {
             return developmentScope
         }
 
-        @Synchronized
         private fun assertValidApiVersion(uri: Uri) {
             when (getApiVersion(uri)) {
                 API_1 -> {

--- a/modules/provider/implementation/src/test/java/se/eelde/toggles/provider/TogglesProviderConcurrentInitTest.kt
+++ b/modules/provider/implementation/src/test/java/se/eelde/toggles/provider/TogglesProviderConcurrentInitTest.kt
@@ -1,0 +1,91 @@
+package se.eelde.toggles.provider
+
+import android.app.Application
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import se.eelde.toggles.core.TogglesProviderContract
+import se.eelde.toggles.database.TogglesDatabase
+import se.eelde.toggles.provider.di.ToggleTestApplication_Application
+import java.util.concurrent.CountDownLatch
+import javax.inject.Inject
+
+/**
+ * Guards the double-checked first-touch initialisation in getCallingApplication(): when many callers
+ * hit a never-seen calling app concurrently, exactly one application row and exactly one pair of
+ * scopes (default + development) must be created — no duplicates.
+ *
+ * Deliberately performs NO warm-up query in setUp(), so the concurrent queries below ARE the
+ * first interaction with the provider.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+@Config(application = ToggleTestApplication_Application::class, sdk = [Build.VERSION_CODES.P])
+class TogglesProviderConcurrentInitTest {
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    private lateinit var togglesProvider: TogglesProvider
+
+    @Suppress("unused")
+    @Inject
+    lateinit var togglesDatabase: TogglesDatabase
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+
+        val contentProviderController =
+            Robolectric.buildContentProvider(TogglesProvider::class.java)
+                .create("se.eelde.toggles.configprovider")
+        togglesProvider = contentProviderController.get()
+
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        shadowOf(context.packageManager).setApplicationIcon(
+            context.applicationInfo.packageName,
+            ColorDrawable(Color.RED)
+        )
+    }
+
+    @Test
+    fun concurrentFirstTouchCreatesScopesExactlyOnce() {
+        val threadCount = 16
+        val startGate = CountDownLatch(1)
+        val ready = CountDownLatch(threadCount)
+        val threads = (0 until threadCount).map {
+            Thread {
+                ready.countDown()
+                startGate.await()
+                togglesProvider
+                    .query(TogglesProviderContract.scopeUri(), null, null, null, null)
+                    .close()
+            }
+        }
+
+        threads.forEach { it.start() }
+        ready.await()
+        startGate.countDown() // release all callers at once to maximise the first-touch race
+        threads.forEach { it.join() }
+
+        togglesProvider.query(TogglesProviderContract.scopeUri(), null, null, null, null)
+            .use { cursor ->
+                assertEquals(
+                    "Concurrent first touch must create exactly the default + development scopes",
+                    2,
+                    cursor.count
+                )
+            }
+    }
+}

--- a/modules/provider/implementation/src/test/java/se/eelde/toggles/provider/TogglesProviderLockContentionTest.kt
+++ b/modules/provider/implementation/src/test/java/se/eelde/toggles/provider/TogglesProviderLockContentionTest.kt
@@ -1,0 +1,129 @@
+package se.eelde.toggles.provider
+
+import android.app.Application
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import se.eelde.toggles.core.TogglesProviderContract
+import se.eelde.toggles.database.TogglesDatabase
+import se.eelde.toggles.provider.di.ToggleTestApplication_Application
+import java.util.concurrent.CountDownLatch
+import javax.inject.Inject
+import kotlin.system.measureTimeMillis
+
+/**
+ * Guards against lock-contention regressions in the provider's read path.
+ *
+ * Both tests deterministically prove that an unrelated thread holding one of the provider's global
+ * monitors does not block an otherwise-independent read query. When the read path is serialised on
+ * those monitors, N concurrent callers queue behind each other instead of running in parallel.
+ *
+ * The assertions encode the required behaviour: a held monitor must NOT block an independent read.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+@Config(application = ToggleTestApplication_Application::class, sdk = [Build.VERSION_CODES.P])
+class TogglesProviderLockContentionTest {
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    private lateinit var togglesProvider: TogglesProvider
+
+    @Suppress("unused")
+    @Inject
+    lateinit var togglesDatabase: TogglesDatabase
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+
+        val contentProviderController =
+            Robolectric.buildContentProvider(TogglesProvider::class.java)
+                .create("se.eelde.toggles.configprovider")
+        togglesProvider = contentProviderController.get()
+
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        shadowOf(context.packageManager).setApplicationIcon(
+            context.applicationInfo.packageName,
+            ColorDrawable(Color.RED)
+        )
+
+        // Warm up: ensure the calling application + default/development scopes already exist, so the
+        // timed query below is a pure read and not the one-time initialisation path.
+        togglesProvider.query(TogglesProviderContract.scopeUri(), null, null, null, null).close()
+    }
+
+    /**
+     * Every query/insert/update/delete enters [TogglesProvider.query] -> getCallingApplication(),
+     * which is `synchronized(this)`. Holding the provider instance monitor from another thread must
+     * not stall an independent read.
+     */
+    @Test
+    fun instanceMonitorDoesNotSerialiseReads() {
+        val elapsed = timeQueryWhileMonitorHeld(monitor = togglesProvider)
+
+        assertTrue(
+            "Independent read serialised on the provider instance monitor " +
+                "(blocked ${elapsed}ms while another thread held it). " +
+                "getCallingApplication()'s synchronized(this) is on the hot path.",
+            elapsed < HOLD_MILLIS / 2
+        )
+    }
+
+    /**
+     * Scope reads go through getDefaultScope()/getSelectedScope(), which are `@Synchronized` on the
+     * companion object — a single static monitor shared with assertValidApiVersion(). Holding it
+     * from another thread must not stall an independent read.
+     */
+    @Test
+    fun companionMonitorDoesNotSerialiseReads() {
+        val elapsed = timeQueryWhileMonitorHeld(monitor = TogglesProvider.Companion)
+
+        assertTrue(
+            "Independent read serialised on the companion-object monitor " +
+                "(blocked ${elapsed}ms while another thread held it). " +
+                "getDefaultScope()/getSelectedScope()/assertValidApiVersion() share one static lock.",
+            elapsed < HOLD_MILLIS / 2
+        )
+    }
+
+    /**
+     * Holds [monitor] on a background thread for [HOLD_MILLIS], then times a scope query on the
+     * current thread. If the query contends on [monitor], the elapsed time is ~[HOLD_MILLIS];
+     * if it runs independently, it is small.
+     */
+    private fun timeQueryWhileMonitorHeld(monitor: Any): Long {
+        val acquired = CountDownLatch(1)
+        val holder = Thread {
+            synchronized(monitor) {
+                acquired.countDown()
+                Thread.sleep(HOLD_MILLIS)
+            }
+        }
+        holder.start()
+        acquired.await()
+
+        val elapsed = measureTimeMillis {
+            togglesProvider.query(TogglesProviderContract.scopeUri(), null, null, null, null).close()
+        }
+
+        holder.join()
+        return elapsed
+    }
+
+    private companion object {
+        const val HOLD_MILLIS = 1000L
+    }
+}


### PR DESCRIPTION
## Problem

Every `TogglesProvider` operation serialised on two global monitors:

- `synchronized(this)` wrapping the whole of `getCallingApplication()` — entered at the start of every `query`/`insert`/`update`/`delete`/`getType`, and held across a DB read.
- An `@Synchronized` companion-object lock shared by `getDefaultScope()`, `getSelectedScope()`, and `assertValidApiVersion()` — the last of which touches no shared state at all (it only parses a URI query parameter).

Under concurrent callers (many parallel flag reads), this turned ~1–2ms uncontended queries into queue waits of up to ~146ms each — a large aggregate stall.

## Fix

Mutual exclusion is only needed for first-touch initialisation (create the calling application row + its default/development scopes, once per install). API-version checks are pure functions and scope lookups are Room reads that SQLite already makes concurrency-safe.

- `getCallingApplication()`: read unlocked; double-checked locking on a dedicated `initLock` only when creating a never-seen calling app. Steady state is now lock-free.
- Removed `@Synchronized` from `getDefaultScope()` / `getSelectedScope()` / `assertValidApiVersion()`.

No schema migration, no public/published-library changes.

## Tests

- `TogglesProviderLockContentionTest` — deterministic reproduction: an independent read previously blocked ~1008ms (instance monitor) / ~1006ms (companion monitor) while another thread held the lock; it now runs unserialised.
- `TogglesProviderConcurrentInitTest` — 16 concurrent first-touch callers create exactly one application row and the two expected scopes (no duplicates), guarding the double-checked init.

Full provider unit suite: 91 tests, 0 failures, 0 skipped. `:modules:provider:implementation:detekt` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)